### PR TITLE
do not set ownerref if resource is deployed into different namespace

### DIFF
--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -633,12 +633,16 @@ func (ghsi *SubscriberItem) subscribeResource(file []byte) (*unstructured.Unstru
 	// Set app label
 	utils.SetPartOfLabel(ghsi.SubscriberItem.Subscription, rsc)
 
-	rsc.SetOwnerReferences([]metav1.OwnerReference{{
-		APIVersion: subscriptionGVK.GroupVersion().String(),
-		Kind:       subscriptionGVK.Kind,
-		Name:       ghsi.Subscription.Name,
-		UID:        ghsi.Subscription.UID,
-	}})
+	// If resource namespace is different than the subscription namespace, setting the owner ref
+	// will cause the resource to be deleted by k8s garbage collection
+	if rsc.GetNamespace() == ghsi.Subscription.Namespace {
+		rsc.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: subscriptionGVK.GroupVersion().String(),
+			Kind:       subscriptionGVK.Kind,
+			Name:       ghsi.Subscription.Name,
+			UID:        ghsi.Subscription.UID,
+		}})
+	}
 
 	return rsc, &validgvk, nil
 }

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
@@ -464,12 +464,16 @@ func (obsi *SubscriberItem) doSubscribeManifest(template *unstructured.Unstructu
 		return nil, errors.New(errmsg)
 	}
 
-	template.SetOwnerReferences([]metav1.OwnerReference{{
-		APIVersion: SubscriptionGVK.GroupVersion().String(),
-		Kind:       SubscriptionGVK.Kind,
-		Name:       obsi.Subscription.Name,
-		UID:        obsi.Subscription.UID,
-	}})
+	// If resource namespace is different than the subscription namespace, setting the owner ref
+	// will cause the resource to be deleted by k8s garbage collection
+	if template.GetNamespace() == obsi.Subscription.Namespace {
+		template.SetOwnerReferences([]metav1.OwnerReference{{
+			APIVersion: SubscriptionGVK.GroupVersion().String(),
+			Kind:       SubscriptionGVK.Kind,
+			Name:       obsi.Subscription.Name,
+			UID:        obsi.Subscription.UID,
+		}})
+	}
 
 	validgvk := template.GetObjectKind().GroupVersionKind()
 


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

When resources are deployed into different namespaces by subscription-admin, do not set owner reference to the subscription. k8s garbage collection will delete the resources because it cannot find the owner in the same namespace.