### PR TITLE
Fix Helm subscription resource list population when charts contains CR(s) that the Hub cluster doesn't have CRD 

### DIFF
--- a/pkg/controller/mcmhub/metaupdate.go
+++ b/pkg/controller/mcmhub/metaupdate.go
@@ -36,9 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/resource"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	cached "k8s.io/client-go/discovery/cached"
@@ -62,9 +59,7 @@ import (
 )
 
 const (
-	sep             = ","
-	helmChartParent = "helmchart"
-	hookParent      = "hook"
+	hookParent = "hook"
 )
 
 var _ genericclioptions.RESTClientGetter = &restClientGetter{}
@@ -118,102 +113,6 @@ func ObjectString(obj metav1.Object) string {
 	return fmt.Sprintf("%v/%v", obj.GetNamespace(), obj.GetName())
 }
 
-func generateResrouceList(hubCfg *rest.Config, helmRls []*releasev1.HelmRelease) (string, error) {
-	res := make([]string, 0)
-	cfg := rest.CopyConfig(hubCfg)
-
-	for _, helmRl := range helmRls {
-		resList, err := GenerateResourceListByConfig(cfg, helmRl)
-		if err != nil {
-			return "", gerr.Wrap(err, "failed to get resource string")
-		}
-
-		res = append(res, parseHelmResourceList(fmt.Sprintf("%v-", helmRl.GetName()), resList))
-	}
-
-	return strings.Join(res, sep), nil
-}
-
-type resourceUnit struct {
-	// it should be helmchart
-	parentType string
-	// for helm resource, it will prefix with this when doing dry-run
-	namePrefix string
-	name       string
-	namespace  string
-	kind       string
-	addition   int
-}
-
-func (r resourceUnit) String() string {
-	return fmt.Sprintf("%v/%v/%v/%v/%v/%v", r.parentType, r.namePrefix, r.kind, r.namespace, r.name, r.addition)
-}
-
-func parseHelmResourceList(helmName string, rs kube.ResourceList) string {
-	res := make([]string, 0)
-
-	for _, resInfo := range rs {
-		t := infoToUnit(resInfo)
-		res = append(res, addParentInfo(&t, helmChartParent, helmName).String())
-	}
-
-	return strings.Join(res, sep)
-}
-
-func infoToUnit(ri *resource.Info) resourceUnit {
-	addition := processAddition(ri.Object)
-
-	return resourceUnit{
-		name:      ri.Name,
-		namespace: ri.Namespace,
-		kind:      ri.Object.GetObjectKind().GroupVersionKind().Kind,
-		addition:  addition,
-	}
-}
-
-func addParentInfo(ri *resourceUnit, ptype, prefix string) resourceUnit {
-	ri.parentType = ptype
-	ri.namePrefix = prefix
-
-	rname := ri.name
-	ri.name = strings.Replace(rname, prefix, "", 1)
-
-	return *ri
-}
-
-func processAddition(obj runtime.Object) int {
-	// need to  add more replicas related type over here
-	switch k := obj.GetObjectKind().GroupVersionKind().Kind; k {
-	case "Deployment", "ReplicaSet", "StatefulSet":
-		return getAdditionValue(obj)
-	default:
-		return 0
-	}
-}
-
-func getAdditionValue(obj runtime.Object) int {
-	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		klog.Error(err)
-		return -1
-	}
-
-	if unstructuredObj == nil {
-		return -1
-	}
-
-	spec := unstructuredObj["spec"]
-	if md, ok := spec.(map[string]interface{}); ok && md != nil {
-		if v, f := md["replicas"]; f && v != nil {
-			if w, g := v.(int64); g {
-				return int(w)
-			}
-		}
-	}
-
-	return -1
-}
-
 //downloadChart downloads the chart
 func downloadChart(client client.Client, s *releasev1.HelmRelease) (string, error) {
 	configMap, err := rUtils.GetConfigMap(client, s.Namespace, s.Repo.ConfigMapRef)
@@ -262,40 +161,33 @@ func getHelmTopoResources(hubClt client.Client, hubCfg *rest.Config, channel, se
 	cfg := rest.CopyConfig(hubCfg)
 
 	for _, helmRl := range helmRls {
-		resList, err := GenerateResourceListByConfig(cfg, helmRl)
+		objList, err := GenerateResourceListByConfig(cfg, helmRl)
 		if err != nil {
-			return nil, gerr.Wrap(err, "failed to get resource string")
+			return nil, gerr.Wrap(err, "failed to get object lists")
 		}
 
-		for _, resInfo := range resList {
-			errs := validation.IsDNS1123Subdomain(resInfo.Name)
+		for _, obj := range objList {
+			errs := validation.IsDNS1123Subdomain(obj.Name)
 			if len(errs) > 0 {
-				errs = append([]string{fmt.Sprintf("Invalid %s name '%s'", resInfo.Object.GetObjectKind().GroupVersionKind().Kind, resInfo.Name)}, errs...)
+				errs = append([]string{fmt.Sprintf("Invalid %s name '%s'", obj.Kind, obj.Name)}, errs...)
 				errMsgs = append(errMsgs, strings.Join(errs, ","))
 			}
 
-			resource := &v1.ObjectReference{
-				Kind:       resInfo.Object.GetObjectKind().GroupVersionKind().Kind,
-				Namespace:  resInfo.Namespace,
-				Name:       resInfo.Name,
-				APIVersion: resInfo.Object.GetObjectKind().GroupVersionKind().Version,
-			}
-
 			// No need to save the namespace object to the resource list of the appsub
-			if resource.Kind == "Namespace" {
+			if obj.Kind == "Namespace" {
 				continue
 			}
 
 			// respect object customized namespace if the appsub user is subscription admin, or apply it to appsub namespace
 			if isAdmin {
-				if resource.Namespace == "" {
-					resource.Namespace = sub.Namespace
+				if obj.Namespace == "" {
+					obj.Namespace = sub.Namespace
 				}
 			} else {
-				resource.Namespace = sub.Namespace
+				obj.Namespace = sub.Namespace
 			}
 
-			resources = append(resources, resource)
+			resources = append(resources, obj)
 		}
 	}
 
@@ -307,7 +199,7 @@ func getHelmTopoResources(hubClt client.Client, hubCfg *rest.Config, channel, se
 }
 
 //generateResourceList generates the resource list for given HelmRelease
-func generateResourceList(mgr manager.Manager, s *releasev1.HelmRelease) (kube.ResourceList, error) {
+func generateResourceList(mgr manager.Manager, s *releasev1.HelmRelease) ([]*v1.ObjectReference, error) {
 	chartDir, err := downloadChart(mgr.GetClient(), s)
 	if err != nil {
 		klog.Error(err, " - Failed to download the chart")
@@ -360,8 +252,6 @@ func generateResourceList(mgr manager.Manager, s *releasev1.HelmRelease) (kube.R
 		return nil, err
 	}
 
-	var resources []*resource.Info
-
 	// parse the manifest into individual yaml content
 	caps, err := rHelper.GetCapabilities(actionConfig)
 	if err != nil {
@@ -375,13 +265,37 @@ func generateResourceList(mgr manager.Manager, s *releasev1.HelmRelease) (kube.R
 		return nil, err
 	}
 
+	resources := []*v1.ObjectReference{}
+
 	// for each content try to build a k8s resource, if successful add it to the list of return
 	for _, file := range files {
-		res, err := kubeClient.Build(bytes.NewBufferString(file.Content), false)
+		resList, err := kubeClient.Build(bytes.NewBufferString(file.Content), false)
 		if err == nil {
-			resources = append(resources, res...)
+			for _, resInfo := range resList {
+				if resInfo.Object != nil && resInfo.Object.GetObjectKind() != nil {
+					resource := &v1.ObjectReference{
+						Kind:       resInfo.Object.GetObjectKind().GroupVersionKind().Kind,
+						APIVersion: resInfo.Object.GetObjectKind().GroupVersionKind().Version,
+						Name:       resInfo.Name,
+						Namespace:  resInfo.Namespace,
+					}
+
+					resources = append(resources, resource)
+				}
+			}
 		} else {
-			klog.Warning("unable to build kubernetes objects from release manifest: %w", err)
+			klog.Warning("unable to build kubernetes objects from release manifest, using just file content: %w", err)
+
+			if file.Head != nil {
+				res := &v1.ObjectReference{
+					Kind:       file.Head.Kind,
+					APIVersion: file.Head.Version,
+					Name:       file.Name,
+					Namespace:  s.Namespace,
+				}
+
+				resources = append(resources, res)
+			}
 		}
 	}
 
@@ -393,7 +307,7 @@ func generateResourceList(mgr manager.Manager, s *releasev1.HelmRelease) (kube.R
 //give us the flexiblity to modify the function parameters,which helped to pass
 //test case.
 //generates the resource list for given HelmRelease
-func GenerateResourceListByConfig(cfg *rest.Config, s *releasev1.HelmRelease) (kube.ResourceList, error) {
+func GenerateResourceListByConfig(cfg *rest.Config, s *releasev1.HelmRelease) ([]*v1.ObjectReference, error) {
 	dryRunEventRecorder := record.NewBroadcaster()
 
 	mgr, err := manager.New(cfg, manager.Options{


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Remove some functions that are not used anywhere.
Fix Helm subscription resource list population when charts contains CR(s) that the Hub cluster doesn't have CRD for. Example of `kubectl get appsubreport -o yaml` on Hub cluster:

Before
```
  resources:
  - apiVersion: v1
    kind: ConfigMap
    name: game-demo
    namespace: default
```
After:
```
  resources:
  - apiVersion: v1
    kind: ConfigMap
    name: game-demo
    namespace: default
  - apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    name: manifest-1
    namespace: default
```
The Hub cluster doesn't have the kyverno ClusterPolicy CRD installed but it's still able to display it as part of the resources list.