### PR TITLE
Don't watch placement decision api until it is installed; skip updati…

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -201,6 +201,9 @@ func RunManager() {
 
 	sig := signals.SetupSignalHandler()
 
+	klog.Info("Detecting ACM Placement Decision API...")
+	utils.DetectPlacementDecision(sig, mgr.GetAPIReader())
+
 	klog.Info("Starting the Cmd.")
 
 	// Start addon manager

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -20,6 +20,7 @@ import (
 
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/controller"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/utils"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
@@ -81,6 +82,9 @@ func RunManager() {
 	}
 
 	sig := signals.SetupSignalHandler()
+
+	klog.Info("Detecting ACM managed cluster API ...")
+	utils.DetectClusterRegistry(sig, mgr.GetAPIReader())
 
 	klog.Info("Starting the Cmd.")
 

--- a/pkg/controller/mcmhub/mcmhub_controller.go
+++ b/pkg/controller/mcmhub/mcmhub_controller.go
@@ -343,13 +343,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// in hub, watch for placement decision changes
-	pdMapper := &placementDecisionMapper{mgr.GetClient()}
-	err = c.Watch(
-		&source.Kind{Type: &clusterapi.PlacementDecision{}},
-		handler.EnqueueRequestsFromMapFunc(pdMapper.Map))
+	if utils.IsReadyPlacementDecision(mgr.GetAPIReader()) {
+		pdMapper := &placementDecisionMapper{mgr.GetClient()}
+		err = c.Watch(
+			&source.Kind{Type: &clusterapi.PlacementDecision{}},
+			handler.EnqueueRequestsFromMapFunc(pdMapper.Map))
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/placementrule/utils/placement.go
+++ b/pkg/placementrule/utils/placement.go
@@ -27,9 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	spokeClusterV1 "open-cluster-management.io/api/cluster/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func ToPlaceLocal(placement *appv1alpha1.Placement) bool {
@@ -124,11 +123,12 @@ func IsReadyACMClusterRegistry(clReader client.Reader) bool {
 	err := clReader.List(context.TODO(), cllist, listopts)
 
 	if err == nil {
-		klog.Error("Cluster API service ready")
+		klog.Error("Managed Cluster API ready")
+
 		return true
 	}
 
-	klog.Error("Cluster API service NOT ready: ", err)
+	klog.Error("Managed Cluster API NOT ready: ", err)
 
 	return false
 }


### PR DESCRIPTION
…ng the helmrelease kind resource to appsubstatus

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

Two issues are addressed:

1.  Don't watch placement decision api until it is installed
2. Skip updating the helmrelease kind resource to appsubstatus