### PR TITLE
Add new e2e framework for kubectl related testing. Add placement API tests

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -116,5 +116,6 @@ jobs:
       - name: Run e2e test
         run: |
           make test-e2e
+          make test-e2e-kc
         env:
           KUBECONFIG: /home/runner/.kube/config

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,8 @@ build-e2e:
 test-e2e: build-e2e deploy-ocm deploy-hub
 	./e2e.test -test.v -ginkgo.v
 
+test-e2e-kc:
+	build/e2e-kc.sh
 
 ############################################################
 # generate code and crd 

--- a/build/e2e-kc.sh
+++ b/build/e2e-kc.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+###############################################################################
+# Copyright Contributors to the Open Cluster Management project
+###############################################################################
+
+set -o nounset
+set -o pipefail
+
+### Setup
+echo "SETUP ensure app addon is available"
+kubectl config use-context kind-cluster1
+if kubectl -n open-cluster-management-agent-addon wait --for=condition=available --timeout=300s deploy/multicluster-operators-subscription; then
+    echo "App addon is available"
+else
+    echo "FAILED: App addon is not available"
+fi
+
+### 01-placement
+echo "STARTING test case 01-placement"
+kubectl config use-context kind-hub
+kubectl label managedcluster cluster1 cluster.open-cluster-management.io/clusterset=app-demo --overwrite
+kubectl label managedcluster cluster1 purpose=test --overwrite
+kubectl apply -f test/e2e/cases/01-placement/
+sleep 30
+
+if kubectl get subscriptions.apps.open-cluster-management.io demo-subscription | grep Propagated; then 
+    echo "01-placement: hub subscriptions.apps.open-cluster-management.io status is Propagated"
+else
+    echo "01-placement FAILED: hub subscriptions.apps.open-cluster-management.io status is not Propagated"
+    exit 1
+fi
+
+kubectl config use-context kind-cluster1
+if kubectl get subscriptions.apps.open-cluster-management.io demo-subscription | grep Subscribed; then 
+    echo "01-placement: cluster1 subscriptions.apps.open-cluster-management.io status is Subscribed"
+else
+    echo "01-placement FAILED: cluster1 subscriptions.apps.open-cluster-management.io status is not Subscribed"
+    exit 1
+fi
+
+if kubectl get pod | grep nginx-ingress-simple-controller | grep Running; then
+    echo "01-placement: appsub deployment pod status is Running"
+else
+    echo "01-placement FAILED: appsub deployment pod status is Running"
+    exit 1
+fi
+
+kubectl config use-context kind-hub
+kubectl delete -f test/e2e/cases/01-placement/
+sleep 30
+kubectl config use-context kind-cluster1
+if kubectl get pod | grep nginx-ingress-simple-controller; then
+    echo "01-placement FAILED: appsub deployment pod is not deleted"
+    exit 1
+else
+    echo "01-placement: appsub deployment pod is deleted"
+fi
+echo "PASSED test case 01-placement"
+
+### 02-placementrule
+echo "STARTING test 02-placementrule"
+kubectl config use-context kind-hub
+kubectl apply -f test/e2e/cases/02-placementrule/
+sleep 30
+
+if kubectl get subscriptions.apps.open-cluster-management.io nginx-sub | grep Propagated; then 
+    echo "02-placementrule: hub subscriptions.apps.open-cluster-management.io status is Propagated"
+else
+    echo "02-placementrule FAILED: hub subscriptions.apps.open-cluster-management.io status is not Propagated"
+    exit 1
+fi
+
+kubectl config use-context kind-cluster1
+if kubectl get subscriptions.apps.open-cluster-management.io nginx-sub | grep Subscribed; then 
+    echo "02-placementrule: cluster1 subscriptions.apps.open-cluster-management.io status is Subscribed"
+else
+    echo "02-placementrule FAILED: cluster1 subscriptions.apps.open-cluster-management.io status is not Subscribed"
+    exit 1
+fi
+
+if kubectl get pod | grep nginx-ingress- | grep Running; then
+    echo "02-placementrule: appsub deployment pod status is Running"
+else
+    echo "02-placementrule FAILED: appsub deployment pod status is Running"
+    exit 1
+fi
+
+kubectl config use-context kind-hub
+kubectl delete -f test/e2e/cases/02-placementrule/
+sleep 30
+kubectl config use-context kind-cluster1
+if kubectl get pod | grep nginx-ingress-; then
+    echo "02-placementrule FAILED: appsub deployment pod is not deleted"
+    exit 1
+else
+    echo "02-placementrule: appsub deployment pod is deleted"
+fi
+echo "PASSED test case 02-placementrule"

--- a/test/e2e/cases/01-placement/channel.yaml
+++ b/test/e2e/cases/01-placement/channel.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: demo-helmrepo
+  namespace: default
+spec:
+    type: HelmRepo
+    pathname: https://charts.helm.sh/stable/
+    insecureSkipVerify: true

--- a/test/e2e/cases/01-placement/clusterset.yaml
+++ b/test/e2e/cases/01-placement/clusterset.yaml
@@ -1,0 +1,4 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSet
+metadata:
+  name: app-demo

--- a/test/e2e/cases/01-placement/clustersetbinding.yaml
+++ b/test/e2e/cases/01-placement/clustersetbinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSetBinding
+metadata:
+  name: app-demo
+  namespace: default
+spec:
+  clusterSet: app-demo

--- a/test/e2e/cases/01-placement/placement.yaml
+++ b/test/e2e/cases/01-placement/placement.yaml
@@ -1,0 +1,14 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: demo-placement
+  namespace: default
+spec:
+  numberOfClusters: 1
+  clusterSets:
+    - app-demo
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            purpose: test

--- a/test/e2e/cases/01-placement/subscription.yaml
+++ b/test/e2e/cases/01-placement/subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: demo-subscription
+  namespace: default
+spec:
+  channel: default/demo-helmrepo
+  name: nginx-ingress
+  placement:
+    placementRef: 
+      name: demo-placement
+      kind: Placement
+  packageOverrides:
+  - packageName: nginx-ingress
+    packageAlias: nginx-ingress-simple
+    packageOverrides:
+    - path: spec
+      value:
+        defaultBackend:
+          replicaCount: 2

--- a/test/e2e/cases/02-placementrule/01-channel.yaml
+++ b/test/e2e/cases/02-placementrule/01-channel.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: dev-helmrepo
+  namespace: default
+spec:
+  type: HelmRepo
+  pathname: https://charts.helm.sh/stable/
+  insecureSkipVerify: true
+

--- a/test/e2e/cases/02-placementrule/02-placementrule.yaml
+++ b/test/e2e/cases/02-placementrule/02-placementrule.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: nginx-pr
+  namespace: default
+spec:
+  clusterReplicas: 10

--- a/test/e2e/cases/02-placementrule/02-subscription.yaml
+++ b/test/e2e/cases/02-placementrule/02-subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: nginx-sub
+  namespace: default
+spec:
+  channel: default/dev-helmrepo
+  name: nginx-ingress
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: nginx-pr
+  packageFilter:
+    version: "1.36.3"


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

This new backend app e2e framework is meant for the community to easily add e2e tests without too much learning curves. 
The `e2e-kc.sh` is simply using kubectl client to apply test cases yaml files and asserting the results. It's as close to manual backend testing as possible, to make it easier to add or modify test cases.