### PR TITLE
fix git default branch

### DIFF
--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -312,7 +312,7 @@ func genBranchString(subIns *subv1.Subscription) string {
 		return branch
 	}
 
-	return "master"
+	return "nobranchdummy"
 }
 
 func setBranch(subIns *subv1.Subscription, bName string) {


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

When git branch is not specified in subscription annotation, clone the default repo branch.