### PR TITLE
Include kind in appsubStatus and appsubReport structs

### DIFF
--- a/pkg/controller/appsubsummary/appsubsummary_controller.go
+++ b/pkg/controller/appsubsummary/appsubsummary_controller.go
@@ -209,7 +209,12 @@ func (r *ReconcileAppSubSummary) createOrUpdateAppSubReport(
 
 		klog.V(1).Infof("updating AppSubReport for appsub: %v", appsub)
 
-		appsubReport := &appsubReportV1alpha1.SubscriptionReport{}
+		appsubReport := &appsubReportV1alpha1.SubscriptionReport{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "SubscriptionReport",
+				APIVersion: "apps.open-cluster-management.io/v1alpha1",
+			},
+		}
 		appsubReportKey := types.NamespacedName{
 			Name:      appsubName,
 			Namespace: appsubNs,

--- a/pkg/controller/mcmhub/placement.go
+++ b/pkg/controller/mcmhub/placement.go
@@ -85,9 +85,10 @@ func (r *ReconcileSubscription) getClustersByPlacement(instance *appSubV1.Subscr
 func getDecisionsFromPlacementRef(pref *corev1.ObjectReference, namespace string, kubeClient client.Client) ([]string, error) {
 	klog.V(1).Info("Preparing cluster names from ", pref.Name)
 
-	label := placementLabel
-	if pref.Kind == "PlacementRule" {
-		label = placementRuleLabel
+	label := placementRuleLabel
+
+	if strings.EqualFold(pref.Kind, "Placement") {
+		label = placementLabel
 	}
 
 	// query all placementdecisions of the placement

--- a/pkg/synchronizer/kubernetes/sync_appsubstatus.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus.go
@@ -88,7 +88,12 @@ func (sync *KubeSynchronizer) SyncAppsubClusterStatus(appsub *appv1.Subscription
 		}
 	}
 
-	pkgstatus := &v1alpha1.SubscriptionStatus{}
+	pkgstatus := &v1alpha1.SubscriptionStatus{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "SubscriptionStatus",
+			APIVersion: "apps.open-cluster-management.io/v1alpha1",
+		},
+	}
 	foundPkgStatus := true
 
 	if err := sync.LocalClient.Get(context.TODO(),
@@ -149,7 +154,7 @@ func (sync *KubeSynchronizer) SyncAppsubClusterStatus(appsub *appv1.Subscription
 
 			// Create appsubstatus on appSub NS
 			if err := sync.LocalClient.Create(context.TODO(), pkgstatus); err != nil {
-				klog.Errorf("Error in creating on managed cluster, appsubstatus:%v/%v, err:%v", appsubClusterStatus.AppSub.Namespace, pkgstatusName, err)
+				klog.Errorf("Error in creating appsubstatus:%v/%v, err:%v", appsubClusterStatus.AppSub.Namespace, pkgstatusName, err)
 
 				return err
 			}
@@ -357,7 +362,12 @@ func (sync *KubeSynchronizer) recordAppSubStatusEvents(appsub *appv1.Subscriptio
 
 func buildAppSubStatus(statusName, statusNs, appsubName, appsubNs, cluster string,
 	unitStatuses []v1alpha1.SubscriptionUnitStatus) *v1alpha1.SubscriptionStatus {
-	pkgstatus := &v1alpha1.SubscriptionStatus{}
+	pkgstatus := &v1alpha1.SubscriptionStatus{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "SubscriptionStatus",
+			APIVersion: "apps.open-cluster-management.io/v1alpha1",
+		},
+	}
 	pkgstatus.Namespace = statusNs
 	pkgstatus.Name = statusName
 
@@ -522,7 +532,13 @@ func deleteAppsubReportResult(rClient client.Client, appsubNs, appsubName, clust
 }
 
 func getClusterAppsubReport(rClient client.Client, clusterAppsubReportNs string, create bool) (*v1alpha1.SubscriptionReport, error) {
-	appsubReport := &v1alpha1.SubscriptionReport{}
+	appsubReport := &v1alpha1.SubscriptionReport{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "SubscriptionReport",
+			APIVersion: "apps.open-cluster-management.io/v1alpha1",
+		},
+	}
+
 	appsubReport.Namespace = clusterAppsubReportNs
 	appsubReport.Name = clusterAppsubReportNs
 	klog.V(1).Infof("Get cluster appSubReport: %v/%v", appsubReport.Namespace, appsubReport.Name)

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -17,6 +17,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -115,7 +116,12 @@ func (sync *KubeSynchronizer) PurgeAllSubscribedResources(appsub *appv1alpha1.Su
 
 	klog.Infof("Prepare to purge all resources deployed by the appsub: %v", hostSub.String())
 
-	appSubStatus := &appSubStatusV1alpha1.SubscriptionStatus{}
+	appSubStatus := &appSubStatusV1alpha1.SubscriptionStatus{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "SubscriptionStatus",
+			APIVersion: "apps.open-cluster-management.io/v1alpha1",
+		},
+	}
 
 	appsubStatusName := hostSub.Name
 	appsubStatusNs := hostSub.Namespace

--- a/pkg/utils/policyreport.go
+++ b/pkg/utils/policyreport.go
@@ -69,7 +69,12 @@ func CreateFailedAppsubReportResult(client client.Client, cluster string, appsub
 
 func getClusterAppsubReport(rClient client.Client, clusterAppsubReportNs string,
 	create bool) (*appsubReportV1alpha1.SubscriptionReport, error) {
-	appsubReport := &appsubReportV1alpha1.SubscriptionReport{}
+	appsubReport := &appsubReportV1alpha1.SubscriptionReport{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "SubscriptionReport",
+			APIVersion: "apps.open-cluster-management.io/v1alpha1",
+		},
+	}
 	appsubReport.Namespace = clusterAppsubReportNs
 	appsubReport.Name = clusterAppsubReportNs
 


### PR DESCRIPTION
- Include kind in appsubStatus and appsubReport structs
- Handle legacy appsub where placementRef contains just the placement name (does not include `Kind`)
- Update counts (cluster, inprogress) in appsubreport from the dry-run even if the resource list is unchanged

Signed-off-by: Philip Wu <phwu@redhat.com>