### PR TITLE
add app labels to subscription

### DIFF
--- a/pkg/controller/mcmhub/mcmhub_controller_test.go
+++ b/pkg/controller/mcmhub/mcmhub_controller_test.go
@@ -302,8 +302,8 @@ func TestNewAppLabels(t *testing.T) {
 	g.Expect(c.Get(context.TODO(), labeltest1subkey, subscription)).NotTo(gomega.HaveOccurred())
 
 	// Verify that the application labels are added and set with the subscription name
-	g.Expect(string(subscription.Labels["app"])).To(gomega.Equal(labeltest1subkey.Name))
-	g.Expect(string(subscription.Labels["app.kubernetes.io/part-of"])).To(gomega.Equal(labeltest1subkey.Name))
+	g.Expect(subscription.Labels["app"]).To(gomega.Equal(labeltest1subkey.Name))
+	g.Expect(subscription.Labels["app.kubernetes.io/part-of"]).To(gomega.Equal(labeltest1subkey.Name))
 }
 
 func TestSyncAppLabels(t *testing.T) {
@@ -354,7 +354,7 @@ func TestSyncAppLabels(t *testing.T) {
 
 	g.Expect(c.Get(context.TODO(), labeltest2subkey, subscription)).NotTo(gomega.HaveOccurred())
 
-	// Verify that the application labels are synch'd with the exising app label
-	g.Expect(string(subscription.Labels["app"])).To(gomega.Equal("existingAppLabel"))
-	g.Expect(string(subscription.Labels["app.kubernetes.io/part-of"])).To(gomega.Equal("existingAppLabel"))
+	// Verify that the application labels are synch'd with the existing app label
+	g.Expect(subscription.Labels["app"]).To(gomega.Equal("existingAppLabel"))
+	g.Expect(subscription.Labels["app.kubernetes.io/part-of"]).To(gomega.Equal("existingAppLabel"))
 }

--- a/pkg/controller/mcmhub/mcmhub_controller_test.go
+++ b/pkg/controller/mcmhub/mcmhub_controller_test.go
@@ -29,6 +29,8 @@ import (
 	chnv1alpha1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 
 	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+
+	placement "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 )
 
 var (
@@ -80,9 +82,107 @@ var (
 	}
 )
 
+var (
+	labeltest1subkey = types.NamespacedName{
+		Name:      "labeltest1sub",
+		Namespace: "labeltest1namespace",
+	}
+
+	labeltest1Namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labeltest1namespace",
+		},
+	}
+
+	labeltest1Channel = &chnv1alpha1.Channel{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.open-cluster-management.io/v1",
+			Kind:       "Channel",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeltest1channel",
+			Namespace: "labeltest1namespace",
+		},
+		Spec: chnv1alpha1.ChannelSpec{
+			Type: chnv1alpha1.ChannelTypeNamespace,
+		},
+	}
+
+	labeltest1Subscription = &appv1alpha1.Subscription{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.open-cluster-management.io/v1",
+			Kind:       "Subscription",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeltest1sub",
+			Namespace: "labeltest1namespace",
+		},
+		Spec: appv1alpha1.SubscriptionSpec{
+			Channel: "labeltest1namespace/labeltest1channel",
+			Placement: &placement.Placement{
+				PlacementRef: &corev1.ObjectReference{
+					Name: "labeltest1Placement",
+					Kind: "Placement",
+				},
+			},
+		},
+	}
+
+	labeltest1ExpectedRequest = reconcile.Request{NamespacedName: labeltest1subkey}
+)
+
+var (
+	labeltest2subkey = types.NamespacedName{
+		Name:      "labeltest2sub",
+		Namespace: "labeltest2namespace",
+	}
+
+	labeltest2Namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labeltest2namespace",
+		},
+	}
+
+	labeltest2Channel = &chnv1alpha1.Channel{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.open-cluster-management.io/v1",
+			Kind:       "Channel",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeltest2channel",
+			Namespace: "labeltest2namespace",
+		},
+		Spec: chnv1alpha1.ChannelSpec{
+			Type: chnv1alpha1.ChannelTypeNamespace,
+		},
+	}
+
+	labeltest2Subscription = &appv1alpha1.Subscription{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.open-cluster-management.io/v1",
+			Kind:       "Subscription",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeltest2sub",
+			Namespace: "labeltest2namespace",
+		},
+		Spec: appv1alpha1.SubscriptionSpec{
+			Channel: "labeltest2namespace/labeltest2channel",
+			Placement: &placement.Placement{
+				PlacementRef: &corev1.ObjectReference{
+					Name: "labeltest2Placement",
+					Kind: "Placement",
+				},
+			},
+		},
+	}
+
+	labeltest2ExpectedRequest = reconcile.Request{NamespacedName: labeltest2subkey}
+)
+
 var expectedRequest = reconcile.Request{NamespacedName: subkey}
 
-const timeout = time.Second * 2
+const timeout = time.Second * 5
 
 func TestMcMHubReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -157,4 +257,104 @@ func TestDoMCMReconcile(t *testing.T) {
 	defer c.Delete(context.TODO(), instance)
 
 	g.Expect(rec.doMCMHubReconcile(instance)).NotTo(gomega.HaveOccurred())
+}
+
+func TestNewAppLabels(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c = mgr.GetClient()
+
+	rec := newReconciler(mgr)
+
+	recFn, requests := SetupTestReconcile(rec)
+
+	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	// Create the app label test namespace.
+	g.Expect(c.Create(context.TODO(), labeltest1Namespace)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), labeltest1Namespace)
+
+	// Create a channel
+	g.Expect(c.Create(context.TODO(), labeltest1Channel.DeepCopy())).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), labeltest1Channel)
+
+	// Create a subscription
+	g.Expect(c.Create(context.TODO(), labeltest1Subscription)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), labeltest1Subscription)
+
+	time.Sleep(time.Second * 2)
+
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(labeltest1ExpectedRequest)))
+
+	subscription := &appv1alpha1.Subscription{}
+
+	g.Expect(c.Get(context.TODO(), labeltest1subkey, subscription)).NotTo(gomega.HaveOccurred())
+
+	// Verify that the application labels are added and set with the subscription name
+	g.Expect(string(subscription.Labels["app"])).To(gomega.Equal(labeltest1subkey.Name))
+	g.Expect(string(subscription.Labels["app.kubernetes.io/part-of"])).To(gomega.Equal(labeltest1subkey.Name))
+}
+
+func TestSyncAppLabels(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c = mgr.GetClient()
+
+	rec := newReconciler(mgr)
+
+	recFn, requests := SetupTestReconcile(rec)
+
+	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	// Create the app label test namespace.
+	g.Expect(c.Create(context.TODO(), labeltest2Namespace.DeepCopy())).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), labeltest2Namespace)
+
+	// Create a channel
+	g.Expect(c.Create(context.TODO(), labeltest2Channel.DeepCopy())).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), labeltest2Channel)
+
+	labels := make(map[string]string)
+
+	labels["app"] = "existingAppLabel"
+
+	labeltest2Subscription.SetLabels(labels)
+
+	// Create a subscription
+	g.Expect(c.Create(context.TODO(), labeltest2Subscription.DeepCopy())).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), labeltest2Subscription)
+
+	time.Sleep(time.Second * 2)
+
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(labeltest2ExpectedRequest)))
+
+	subscription := &appv1alpha1.Subscription{}
+
+	g.Expect(c.Get(context.TODO(), labeltest2subkey, subscription)).NotTo(gomega.HaveOccurred())
+
+	// Verify that the application labels are synch'd with the exising app label
+	g.Expect(string(subscription.Labels["app"])).To(gomega.Equal("existingAppLabel"))
+	g.Expect(string(subscription.Labels["app.kubernetes.io/part-of"])).To(gomega.Equal("existingAppLabel"))
 }


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Add the following `app` and `app.kubernetes.io/part-of` labels to subscription. The value is the name of the subscription. If `app` label is specified or already exists, `app.kubernetes.io/part-of` label needs to be sync'd with the `app` label.

