### PR TITLE
appstatus deployed on the local-cluster should have the same appsub name

### DIFF
--- a/pkg/subscriber/git/git_subscriber.go
+++ b/pkg/subscriber/git/git_subscriber.go
@@ -81,6 +81,8 @@ func Add(mgr manager.Manager, hubconfig *rest.Config, syncid *types.NamespacedNa
 		return err
 	}
 
+	sync.SkipAppSubStatusResDel = false
+
 	defaultSubscriber = CreateGitHubSubscriber(hubconfig, mgr.GetScheme(), mgr, sync, syncinterval)
 	if defaultSubscriber == nil {
 		errmsg := "failed to create default namespace subscriber"

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber.go
@@ -79,6 +79,8 @@ func Add(mgr manager.Manager, hubconfig *rest.Config, syncid *types.NamespacedNa
 		return err
 	}
 
+	sync.SkipAppSubStatusResDel = false
+
 	defaultSubscriber = CreateObjectBucketSubsriber(hubconfig, mgr.GetScheme(), mgr, sync, syncinterval)
 	if defaultSubscriber == nil {
 		errmsg := "failed to create default namespace subscriber"

--- a/pkg/synchronizer/kubernetes/sync_appsubstatus.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus.go
@@ -80,13 +80,14 @@ func (sync *KubeSynchronizer) SyncAppsubClusterStatus(appsub *appv1.Subscription
 
 	appsubName := appsubClusterStatus.AppSub.Name
 	pkgstatusNs := appsubClusterStatus.AppSub.Namespace
-	pkgstatusName := appsubName
 
 	if isLocalCluster {
 		if strings.HasSuffix(appsubName, "-local") {
 			appsubName = appsubName[:len(appsubName)-6]
 		}
 	}
+
+	pkgstatusName := appsubName
 
 	pkgstatus := &v1alpha1.SubscriptionStatus{
 		TypeMeta: metaV1.TypeMeta{

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -131,8 +131,6 @@ func (sync *KubeSynchronizer) PurgeAllSubscribedResources(appsub *appv1alpha1.Su
 		if strings.HasSuffix(appsubStatusName, "-local") {
 			appsubStatusName = appsubStatusName[:len(appsubStatusName)-6]
 		}
-
-		appsubStatusNs = sync.SynchronizerID.Name
 	}
 
 	appSubStatusKey := types.NamespacedName{


### PR DESCRIPTION
… local-cluster

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/stolostron/backlog/issues/19731

Two issues are found:

1. when appsub is deployed to the local-cluster, its appsubstatus should remove the `-local` suffix. Or the appsubstatus won't be found when the appsub is deleted.

2. SkipAppSubStatusResDel should be initiated to false for git/object store subscriber. it should be true only for helm subscriber. 
