### PR TITLE
Add agent-install-all flag to subscription addon 

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -238,7 +238,7 @@ func RunManager() {
 			os.Exit(1)
 		}
 
-		addon := agentaddon.NewAgent(Options.AgentImage, kubeClient)
+		addon := agentaddon.NewAgent(Options.AgentImage, kubeClient, Options.AgentInstallAll)
 
 		if err := adddonmgr.AddAgent(addon); err != nil {
 			klog.Error("Failed to add addon to addon manager, error:", err)

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -33,6 +33,7 @@ type SubscriptionCMDOptions struct {
 	AgentImage            string
 	LeaseDurationSeconds  int
 	Debug                 bool
+	AgentInstallAll       bool
 }
 
 var Options = SubscriptionCMDOptions{
@@ -140,4 +141,11 @@ func ProcessFlags() {
 		Options.DisableTLS,
 		"Disable TLS on WebHook event listener.",
 	)
+
+	flag.BoolVar(
+		&Options.AgentInstallAll,
+		"agent-install-all",
+		false,
+		"Configure the install strategy of agent on managed clusters. "+
+			"Enabling this will automatically install agent on all managed cluster.")
 }

--- a/pkg/addonmanager/addon.go
+++ b/pkg/addonmanager/addon.go
@@ -22,7 +22,10 @@ import (
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/addonmanager/bindata"
 )
 
-const roleName = "application-manager-agent"
+const (
+	roleName                     = "application-manager-agent"
+	addonDefaultInstallNamespace = "open-cluster-management-agent-addon"
+)
 
 var (
 	genericScheme    = runtime.NewScheme()
@@ -49,14 +52,22 @@ func init() {
 }
 
 type subscriptionAgent struct {
-	agentImage string
-	kubeClient kubernetes.Interface
+	agentImage           string
+	kubeClient           kubernetes.Interface
+	agentInstallStrategy *agent.InstallStrategy
 }
 
-func NewAgent(agentImage string, kubeClient kubernetes.Interface) agent.AgentAddon {
+func NewAgent(agentImage string, kubeClient kubernetes.Interface, agentInstallAllStrategy bool) agent.AgentAddon {
+	var agentInstallStrategy *agent.InstallStrategy
+	agentInstallStrategy = nil
+	if agentInstallAllStrategy == true {
+		agentInstallStrategy = agent.InstallAllStrategy(addonDefaultInstallNamespace)
+	}
+
 	return &subscriptionAgent{
-		agentImage: agentImage,
-		kubeClient: kubeClient,
+		agentImage:           agentImage,
+		kubeClient:           kubeClient,
+		agentInstallStrategy: agentInstallStrategy,
 	}
 }
 
@@ -108,7 +119,8 @@ func (s *subscriptionAgent) Manifests(cluster *clusterv1.ManagedCluster, addon *
 
 func (s *subscriptionAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 	return agent.AgentAddonOptions{
-		AddonName: "application-manager",
+		AddonName:       "application-manager",
+		InstallStrategy: s.agentInstallStrategy,
 		Registration: &agent.RegistrationOption{
 			CSRConfigurations: agent.KubeClientSignerConfigurations("application-manager", "appmgr"),
 			CSRApproveCheck: func(

--- a/pkg/addonmanager/addon.go
+++ b/pkg/addonmanager/addon.go
@@ -58,9 +58,9 @@ type subscriptionAgent struct {
 }
 
 func NewAgent(agentImage string, kubeClient kubernetes.Interface, agentInstallAllStrategy bool) agent.AgentAddon {
-	var agentInstallStrategy *agent.InstallStrategy
-	agentInstallStrategy = nil
-	if agentInstallAllStrategy == true {
+	var agentInstallStrategy *agent.InstallStrategy = nil
+
+	if agentInstallAllStrategy {
 		agentInstallStrategy = agent.InstallAllStrategy(addonDefaultInstallNamespace)
 	}
 

--- a/pkg/addonmanager/addon_test.go
+++ b/pkg/addonmanager/addon_test.go
@@ -37,7 +37,7 @@ func TestManifests(t *testing.T) {
 
 	fakeKubeClient := fakekube.NewSimpleClientset()
 
-	agent := NewAgent("test", fakeKubeClient)
+	agent := NewAgent("test", fakeKubeClient, false)
 
 	objects, err := agent.Manifests(cluster, addon)
 
@@ -80,7 +80,7 @@ func TestPermissionFunc(t *testing.T) {
 
 	fakeKubeClient := fakekube.NewSimpleClientset()
 
-	agent := NewAgent("test", fakeKubeClient)
+	agent := NewAgent("test", fakeKubeClient, false)
 
 	err := agent.GetAgentAddonOptions().Registration.PermissionConfig(cluster, addon)
 


### PR DESCRIPTION
Addon could be automatically installed on all managed cluster.

The choice that if automatically installed on all managed cluster should be made by user.

If this flag is not supported, someone who want to installed all must watches ManagedCluster and creates ManagedClusterAddon to new cluster namespace, but this has be implement in addon-framework.