### PR TITLE
add mergeAndOwn option

### DIFF
--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -102,6 +102,8 @@ const (
 	MergeReconcile = "merge"
 	// ReplaceReconcile replaces fields in resources using kubernetes update
 	ReplaceReconcile = "replace"
+	// MergeAndOwnReconcile creates or updates fields in resources using kubernetes patch and take ownership of the resource
+	MergeAndOwnReconcile = "mergeAndOwn"
 	// SubscriptionNameSuffix is appended to the subscription name when propagated to managed clusters
 	SubscriptionNameSuffix = ""
 	// ChannelCertificateData is the configmap data spec field containing trust certificates


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Add `apps.open-cluster-management.io/reconcile-option: mergeAndOwn` option in subscription so that user with subscription-admin role can claim ownership of existing resources with merge option.