### PR TITLE
use manualSelector for job in addon

### DIFF
--- a/addon/manifests/chart/templates/pre_delete_hook.yaml
+++ b/addon/manifests/chart/templates/pre_delete_hook.yaml
@@ -7,6 +7,10 @@ metadata:
     component: "application-manager"
     "open-cluster-management.io/addon-pre-delete": ""
 spec:
+  manualSelector: true
+  selector:
+    matchLabels:
+      component: "application-manager"
   template:
     metadata:
       name: "{{ template "application-manager.fullname" . }}-predelete"


### PR DESCRIPTION
use manualSelector for the job in addon since the manifestwork cannot handle job upgrade.

Signed-off-by: Zhiwei Yin <zyin@redhat.com>