### PR TITLE
include helmrelease in appsubstatus

### DIFF
--- a/build/e2e-kc.sh
+++ b/build/e2e-kc.sh
@@ -39,6 +39,13 @@ else
     exit 1
 fi
 
+if kubectl get subscriptionstatus.apps.open-cluster-management.io demo-subscription -o yaml | grep InstallSuccessful; then 
+    echo "01-placement: found InstallSuccessful in subscription status output"
+else
+    echo "01-placement: FAILED: InstallSuccessful is not in the subscription status output"
+    exit 1
+fi
+
 if kubectl get pod | grep nginx-ingress-simple-controller | grep Running; then
     echo "01-placement: appsub deployment pod status is Running"
 else
@@ -76,6 +83,13 @@ if kubectl get subscriptions.apps.open-cluster-management.io nginx-sub | grep Su
     echo "02-placementrule: cluster1 subscriptions.apps.open-cluster-management.io status is Subscribed"
 else
     echo "02-placementrule FAILED: cluster1 subscriptions.apps.open-cluster-management.io status is not Subscribed"
+    exit 1
+fi
+
+if kubectl get subscriptionstatus.apps.open-cluster-management.io nginx-sub -o yaml | grep InstallSuccessful; then 
+    echo "02-placementrule: found InstallSuccessful in subscription status output"
+else
+    echo "02-placementrule: FAILED: InstallSuccessful is not in the subscription status output"
     exit 1
 fi
 


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

```
    - apiVersion: apps/v1
      kind: Deployment
      lastUpdateTime: "2022-03-24T01:00:43Z"
      name: nginx-ingress-1c74f-default-backend
      namespace: default
      phase: Deployed
    - apiVersion: apps.open-cluster-management.io/v1
      kind: HelmRelease
      lastUpdateTime: "2022-03-24T01:00:43Z"
      message: InstallSuccessful
      name: nginx-ingress-1c74f
      namespace: default
      phase: Deployed

```
I want to show the InstallSuccessful or UpgradeSuccessful message in the appsubstatus