### PR TITLE
evaluate user access to managed cluster by selfSubjectAccess with Imp…

### DIFF
--- a/pkg/controller/mcmhub/hook.go
+++ b/pkg/controller/mcmhub/hook.go
@@ -658,7 +658,7 @@ func GetClustersByPlacement(instance *subv1.Subscription, kubeclient client.Clie
 		if instance.Spec.Placement.PlacementRef != nil {
 			clusters, err = getClustersFromPlacementRef(instance, kubeclient, logger)
 		} else {
-			clustermap, err := placementutils.PlaceByGenericPlacmentFields(kubeclient, instance.Spec.Placement.GenericPlacementFields, nil, instance)
+			clustermap, err := placementutils.PlaceByGenericPlacmentFields(kubeclient, instance.Spec.Placement.GenericPlacementFields, instance)
 			if err != nil {
 				logger.Error(err, " - Failed to get clusters from generic fields with error.")
 				return nil, err

--- a/pkg/controller/mcmhub/placement.go
+++ b/pkg/controller/mcmhub/placement.go
@@ -58,7 +58,7 @@ func (r *ReconcileSubscription) getClustersByPlacement(instance *appSubV1.Subscr
 	if instance.Spec.Placement.PlacementRef != nil {
 		clusters, err = r.getClustersFromPlacementRef(instance)
 	} else {
-		clustermap, err := placementutils.PlaceByGenericPlacmentFields(r.Client, instance.Spec.Placement.GenericPlacementFields, nil, instance)
+		clustermap, err := placementutils.PlaceByGenericPlacmentFields(r.Client, instance.Spec.Placement.GenericPlacementFields, instance)
 		if err != nil {
 			klog.Error("Failed to get clusters from generic fields with error: ", err)
 			return nil, err

--- a/pkg/placementrule/controller/placementrule/placementrule_controller.go
+++ b/pkg/placementrule/controller/placementrule/placementrule_controller.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,11 +49,8 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	authCfg := mgr.GetConfig()
-	authCfg.QPS = 100.0
-	authCfg.Burst = 200
-	kubeClient := kubernetes.NewForConfigOrDie(authCfg)
 
-	return &ReconcilePlacementRule{Client: mgr.GetClient(), scheme: mgr.GetScheme(), authClient: kubeClient}
+	return &ReconcilePlacementRule{Client: mgr.GetClient(), scheme: mgr.GetScheme(), authConfig: authCfg}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -94,7 +91,7 @@ var _ reconcile.Reconciler = &ReconcilePlacementRule{}
 // ReconcilePlacementRule reconciles a PlacementRule object
 type ReconcilePlacementRule struct {
 	client.Client
-	authClient kubernetes.Interface
+	authConfig *rest.Config
 	scheme     *runtime.Scheme
 }
 

--- a/pkg/placementrule/utils/placement.go
+++ b/pkg/placementrule/utils/placement.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	spokeClusterV1 "open-cluster-management.io/api/cluster/v1"
 	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -43,7 +42,7 @@ func ToPlaceLocal(placement *appv1alpha1.Placement) bool {
 // Top priority: clusterNames, ignore selector
 // Bottomline: Use label selector
 func PlaceByGenericPlacmentFields(kubeclient client.Client, placement appv1alpha1.GenericPlacementFields,
-	authclient kubernetes.Interface, object runtime.Object) (map[string]*spokeClusterV1.ManagedCluster, error) {
+	object runtime.Object) (map[string]*spokeClusterV1.ManagedCluster, error) {
 	clmap := make(map[string]*spokeClusterV1.ManagedCluster)
 
 	var labelSelector *metav1.LabelSelector

--- a/pkg/placementrule/utils/utils_test.go
+++ b/pkg/placementrule/utils/utils_test.go
@@ -159,7 +159,7 @@ func TestPlacementRule(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// test PlaceByGenericPlacmentFields
-	clmap, err := PlaceByGenericPlacmentFields(c, placementrule1.Spec.GenericPlacementFields, kubeClient, placementrule1)
+	clmap, err := PlaceByGenericPlacmentFields(c, placementrule1.Spec.GenericPlacementFields, placementrule1)
 
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(len(clmap)).To(gomega.Equal(1))


### PR DESCRIPTION
…ersonate user kube client

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/stolostron/backlog/issues/21133
https://github.com/stolostron/backlog/issues/20916

It turns out the SubjectAccessReview.status is not reliable if both Allowed and Denied are false. 

In #20916, the user is cluster admin. The user can list all managed clusters.
In #21133, the user is just cluster admin just in default NS (defined by the rolebinding), the user is not granted to get managedCluster. 

But in both cases, the SubjectAccessReview.status returns the same result `Allowed:false, Denied:false`

The fix is to switch to apply SelfSubjectAccessReview CR with impersonate user kube client. The method is used by k8s official CLI `oc auth can-i`
