### PR TITLE
placement rule controller performance enhacement

### DIFF
--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -64,8 +64,8 @@ func RunManager() {
 		}
 	}
 
-	cfg.QPS = 100.0
-	cfg.Burst = 200
+	cfg.QPS = 30.0
+	cfg.Burst = 60
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),

--- a/pkg/placementrule/controller/placementrule/placementrule_status_controller.go
+++ b/pkg/placementrule/controller/placementrule/placementrule_status_controller.go
@@ -65,7 +65,7 @@ func genReconciler(mgr manager.Manager) reconcile.Reconciler {
 func addRec(mgr manager.Manager, r reconcile.Reconciler) error {
 	c, err := controller.New("placementrule-status-controller", mgr, controller.Options{
 		Reconciler:              r,
-		MaxConcurrentReconciles: 10,
+		MaxConcurrentReconciles: 2,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The placmentrule performance got improved after applying the fix on 1k managed cluster with 1k placementrule

1. the memory consumption dropped to ~300M (memory limit is set to 700M in the 1k env)
2. the CPU consumption dropped to 1000m (CPU limit is set to 1500M in the 1k env)

The placementrule container has been running for 2 hours without restart.