### PR TITLE
don't include namespace for cluster scoped resources

### DIFF
--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -307,8 +307,6 @@ func (r *ReconcileSubscription) createAppAppsubReport(sub *appv1alpha1.Subscript
 		pkgGroup, pkgVersion := utils.ParseAPIVersion(resource.APIVersion)
 
 		if pkgGroup == "" && pkgVersion == "" {
-			resource.Namespace = ""
-
 			klog.Infof("invalid apiversion: %v", resource)
 		} else {
 			isNamespaced := r.IsNamespacedResource(pkgGroup, pkgVersion, resource.Kind)

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -43,6 +42,7 @@ import (
 	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	appsubreportv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1alpha1"
 	helmops "open-cluster-management.io/multicloud-operators-subscription/pkg/subscriber/helmrepo"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
 	awsutils "open-cluster-management.io/multicloud-operators-subscription/pkg/utils/aws"
 )
 
@@ -274,8 +274,51 @@ func (r *ReconcileSubscription) GetChannelGeneration(s *appv1alpha1.Subscription
 	return strconv.FormatInt(chobj.Generation, 10), nil
 }
 
+func (r *ReconcileSubscription) IsNamespacedResource(group, version, kind string) bool {
+	pkgGK := schema.GroupKind{
+		Kind:  kind,
+		Group: group,
+	}
+
+	mapping, err := r.restMapper.RESTMapping(pkgGK, version)
+	if err != nil {
+		klog.Errorf("Failed to get GVR from restmapping: group: %v, version: %v, kind: %v, err:%v",
+			group, version, kind, err)
+
+		return false
+	}
+
+	var isNamespaced bool = true
+
+	if mapping.Scope.Name() != "namespace" {
+		isNamespaced = false
+	}
+
+	klog.Infof("group: %v, version: %v, kind: %v, scope: %#v, isNamespaced: %v",
+		group, version, kind, mapping.Scope, isNamespaced)
+
+	return isNamespaced
+}
+
 func (r *ReconcileSubscription) createAppAppsubReport(sub *appv1alpha1.Subscription, resources []*v1.ObjectReference,
 	propagationFailedCount, clusterCount int) error {
+	// remove resource.namespace if the resource is cluster scoped
+	for _, resource := range resources {
+		pkgGroup, pkgVersion := utils.ParseAPIVersion(resource.APIVersion)
+
+		if pkgGroup == "" && pkgVersion == "" {
+			resource.Namespace = ""
+
+			klog.Infof("invalid apiversion: %v", resource)
+		} else {
+			isNamespaced := r.IsNamespacedResource(pkgGroup, pkgVersion, resource.Kind)
+
+			if !isNamespaced {
+				resource.Namespace = ""
+			}
+		}
+	}
+
 	appsubReport := &appsubreportv1alpha1.SubscriptionReport{
 		TypeMeta: metaV1.TypeMeta{
 			Kind:       "SubscriptionReport",
@@ -330,19 +373,16 @@ func (r *ReconcileSubscription) createAppAppsubReport(sub *appv1alpha1.Subscript
 			return err
 		}
 	} else {
-		klog.V(1).Infof("App appsubReport found: %v/%v, update it.", appsubReport.Namespace, appsubReport.Name)
+		klog.Infof("App appsubReport found: %v/%v, update it.", appsubReport.Namespace, appsubReport.Name)
 
 		if propagationFailedCount > 0 {
-			klog.V(1).Infof("Failed to get clusters from placement, exit without updating appsubReport")
+			klog.Infof("Failed to get clusters from placement, exit without updating appsubReport")
 
 			return nil
 		}
 
-		if resources != nil && (appsubReport.Resources == nil || !reflect.DeepEqual(appsubReport.Resources, resources)) {
-			appsubReport.Resources = resources
-		} else {
-			klog.V(1).Infof("App appsubReport(%v/%v) resource list unchanged.", appsubReport.Namespace, appsubReport.Name)
-		}
+		// Always apply the new resources list
+		appsubReport.Resources = resources
 
 		// update counts
 		deployed, err := strconv.Atoi(appsubReport.Summary.Deployed)

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -282,10 +282,10 @@ func (r *ReconcileSubscription) IsNamespacedResource(group, version, kind string
 
 	mapping, err := r.restMapper.RESTMapping(pkgGK, version)
 	if err != nil {
-		klog.Errorf("Failed to get GVR from restmapping: group: %v, version: %v, kind: %v, err:%v",
+		klog.Errorf("Failed to get GVR from restmapping, keep the original namespace: group: %v, version: %v, kind: %v, err:%v",
 			group, version, kind, err)
 
-		return false
+		return true
 	}
 
 	var isNamespaced bool = true

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -260,6 +260,7 @@ func (sync *KubeSynchronizer) ProcessSubResources(appsub *appv1alpha1.Subscripti
 		}
 
 		if err != nil {
+			appSubUnitStatus.Namespace = resource.Resource.GetNamespace()
 			appSubUnitStatus.Phase = string(appSubStatusV1alpha1.PackageDeployFailed)
 			appSubUnitStatus.Message = err.Error()
 			appSubUnitStatuses = append(appSubUnitStatuses, appSubUnitStatus)

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -252,9 +252,12 @@ func (sync *KubeSynchronizer) ProcessSubResources(appsub *appv1alpha1.Subscripti
 		appSubUnitStatus.APIVersion = resource.Resource.GetAPIVersion()
 		appSubUnitStatus.Kind = resource.Resource.GetKind()
 		appSubUnitStatus.Name = resource.Resource.GetName()
-		appSubUnitStatus.Namespace = resource.Resource.GetNamespace()
 
 		pkgGVR, isNamespaced, err := sync.getGVRfromGVK(resource.Gvk.Group, resource.Gvk.Version, resource.Gvk.Kind)
+
+		if isNamespaced {
+			appSubUnitStatus.Namespace = resource.Resource.GetNamespace()
+		}
 
 		if err != nil {
 			appSubUnitStatus.Phase = string(appSubStatusV1alpha1.PackageDeployFailed)


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/stolostron/backlog/issues/21477

The fix has two parts:
1. when generating the subscriptionStatus, the cluster scoped resources should not include namespace
2. In the app subscriptionReport resource list, the cluster scoped resources should not include namespace as well
