### PR TITLE
do not watch appmgr SA token secret

### DIFF
--- a/pkg/controller/spoketoken/spoke_token_controller.go
+++ b/pkg/controller/spoketoken/spoke_token_controller.go
@@ -89,12 +89,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to klusterlet-addon-appmgr service account token secret in open-cluster-management-agent-addon namespace.
-	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, utils.AddonSATokenSecretPredicateFunctions)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -396,38 +396,6 @@ var ServiceAccountPredicateFunctions = predicate.Funcs{
 	},
 }
 
-// AddonSATokenSecretPredicateFunctions watches for changes in klusterlet-addon-appmgr
-// service account token secret in open-cluster-management-agent-addon namespace
-var AddonSATokenSecretPredicateFunctions = predicate.Funcs{
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		newSecret := e.ObjectNew.(*corev1.Secret)
-
-		if strings.EqualFold(newSecret.Namespace, addonServiceAccountNamespace) && strings.HasPrefix(newSecret.Name, addonServiceAccountName+"-token-") {
-			return true
-		}
-
-		return false
-	},
-	CreateFunc: func(e event.CreateEvent) bool {
-		secret := e.Object.(*corev1.Secret)
-
-		if strings.EqualFold(secret.Namespace, addonServiceAccountNamespace) && strings.HasPrefix(secret.Name, addonServiceAccountName+"-token-") {
-			return true
-		}
-
-		return false
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		secret := e.Object.(*corev1.Secret)
-
-		if strings.EqualFold(secret.Namespace, addonServiceAccountNamespace) && strings.HasPrefix(secret.Name, addonServiceAccountName+"-token-") {
-			return true
-		}
-
-		return false
-	},
-}
-
 // GetHostSubscriptionFromObject extract the namespacedname of subscription hosting the object resource
 func GetHostSubscriptionFromObject(obj metav1.Object) *types.NamespacedName {
 	if obj == nil {


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Watching SA token secret breaks the reconcile code that checks the existence of SA by reconcile request name. We should only watch SA changes (which will change if SA token secret changes).

https://github.com/stolostron/backlog/issues/24073