### PR TITLE
fix appsubreport not generating for local-cluster when the pod dealing with HelmRelease is the standalone pod

### DIFF
--- a/pkg/synchronizer/kubernetes/sync_appsubstatus.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus.go
@@ -78,7 +78,8 @@ func (sync *KubeSynchronizer) SyncAppsubClusterStatus(appsub *appv1.Subscription
 	appsubName := appsubClusterStatus.AppSub.Name
 	pkgstatusNs := appsubClusterStatus.AppSub.Namespace
 	isLocalCluster := (sync.hub && !sync.standalone) ||
-		(appsubClusterStatus.Cluster == localCluster && strings.HasSuffix(appsubName, localSuffix))
+		(appsubClusterStatus.Cluster == localCluster && strings.HasSuffix(appsubName, localSuffix)) ||
+		(sync.standalone && strings.HasSuffix(appsubName, localSuffix))
 
 	if isLocalCluster || sync.standalone && skipOrphanDel {
 		if strings.HasSuffix(appsubName, localSuffix) {


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>