### PR TITLE
Add default controller leader election setting values

### DIFF
--- a/cmd/appsubsummary/exec/manager.go
+++ b/cmd/appsubsummary/exec/manager.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -62,6 +63,9 @@ func RunManager() {
 		}
 	}
 
+	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
+	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -69,6 +73,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-appsubsummary-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 	})
 	if err != nil {
 		klog.Error(err, "")

--- a/cmd/appsubsummary/exec/options.go
+++ b/cmd/appsubsummary/exec/options.go
@@ -20,15 +20,21 @@ import (
 
 // AppSubStatusCMDOptions for command line flag parsing.
 type AppSubStatusCMDOptions struct {
-	MetricsAddr  string
-	KubeConfig   string
-	SyncInterval int
+	MetricsAddr          string
+	KubeConfig           string
+	SyncInterval         int
+	LeaseDurationSeconds int
+	RenewDeadlineSeconds int
+	RetryPeriodSeconds   int
 }
 
 var options = AppSubStatusCMDOptions{
-	MetricsAddr:  "",
-	KubeConfig:   "",
-	SyncInterval: 15,
+	MetricsAddr:          "",
+	KubeConfig:           "",
+	SyncInterval:         15,
+	LeaseDurationSeconds: 137,
+	RenewDeadlineSeconds: 107,
+	RetryPeriodSeconds:   26,
 }
 
 // ProcessFlags parses command line parameters into options.
@@ -54,5 +60,26 @@ func ProcessFlags() {
 		"kubeconfig",
 		options.KubeConfig,
 		"The kube config that points to a external api server.",
+	)
+
+	flag.IntVar(
+		&options.LeaseDurationSeconds,
+		"lease-duration",
+		options.LeaseDurationSeconds,
+		"The lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RenewDeadlineSeconds,
+		"renew-deadline",
+		options.RenewDeadlineSeconds,
+		"The renew deadline in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RetryPeriodSeconds,
+		"retry-period",
+		options.RetryPeriodSeconds,
+		"The retry period in seconds.",
 	)
 }

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -103,6 +103,9 @@ func RunManager() {
 	cfg.QPS = 100.0
 	cfg.Burst = 200
 
+	leaderElectionLeaseDuration := time.Duration(Options.LeaderElectionLeaseDurationSeconds) * time.Second
+	renewDeadline := time.Duration(Options.RenewDeadlineSeconds) * time.Second
+	retryPeriod := time.Duration(Options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -110,6 +113,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        leaderElectionID,
 		LeaderElectionNamespace: "kube-system",
+		LeaseDuration:           &leaderElectionLeaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -20,29 +20,35 @@ import (
 
 // SubscriptionCMDOptions for command line flag parsing
 type SubscriptionCMDOptions struct {
-	MetricsAddr           string
-	KubeConfig            string
-	ClusterName           string
-	HubConfigFilePathName string
-	TLSKeyFilePathName    string
-	TLSCrtFilePathName    string
-	SyncInterval          int
-	DisableTLS            bool
-	Standalone            bool
-	AgentImage            string
-	LeaseDurationSeconds  int
-	Debug                 bool
-	AgentInstallAll       bool
+	MetricsAddr                        string
+	KubeConfig                         string
+	ClusterName                        string
+	HubConfigFilePathName              string
+	TLSKeyFilePathName                 string
+	TLSCrtFilePathName                 string
+	SyncInterval                       int
+	DisableTLS                         bool
+	Standalone                         bool
+	AgentImage                         string
+	LeaseDurationSeconds               int
+	LeaderElectionLeaseDurationSeconds int
+	RenewDeadlineSeconds               int
+	RetryPeriodSeconds                 int
+	Debug                              bool
+	AgentInstallAll                    bool
 }
 
 var Options = SubscriptionCMDOptions{
-	MetricsAddr:          "",
-	KubeConfig:           "",
-	SyncInterval:         60,
-	LeaseDurationSeconds: 60,
-	Standalone:           false,
-	AgentImage:           "quay.io/open-cluster-management/multicloud-operators-subscription:latest",
-	Debug:                false,
+	MetricsAddr:                        "",
+	KubeConfig:                         "",
+	SyncInterval:                       60,
+	LeaseDurationSeconds:               60,
+	LeaderElectionLeaseDurationSeconds: 137,
+	RenewDeadlineSeconds:               107,
+	RetryPeriodSeconds:                 26,
+	Standalone:                         false,
+	AgentImage:                         "quay.io/open-cluster-management/multicloud-operators-subscription:latest",
+	Debug:                              false,
 }
 
 // ProcessFlags parses command line parameters into Options
@@ -89,6 +95,27 @@ func ProcessFlags() {
 		"lease-duration",
 		Options.LeaseDurationSeconds,
 		"The lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&Options.LeaderElectionLeaseDurationSeconds,
+		"leader-election-lease-duration",
+		Options.LeaderElectionLeaseDurationSeconds,
+		"The leader election lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&Options.RenewDeadlineSeconds,
+		"renew-deadline",
+		Options.RenewDeadlineSeconds,
+		"The renew deadline in seconds.",
+	)
+
+	flag.IntVar(
+		&Options.RetryPeriodSeconds,
+		"retry-period",
+		Options.RetryPeriodSeconds,
+		"The retry period in seconds.",
 	)
 
 	flag.BoolVar(

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/controller"
@@ -67,12 +68,18 @@ func RunManager() {
 	cfg.QPS = 30.0
 	cfg.Burst = 60
 
+	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
+	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		Port:                    operatorMetricsPort,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-placementrule-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 	})
 
 	if err != nil {

--- a/cmd/placementrule/exec/options.go
+++ b/cmd/placementrule/exec/options.go
@@ -20,13 +20,19 @@ import (
 
 // PlacementRuleCMDOptions for command line flag parsing
 type PlacementRuleCMDOptions struct {
-	MetricsAddr string
-	KubeConfig  string
+	MetricsAddr          string
+	KubeConfig           string
+	LeaseDurationSeconds int
+	RenewDeadlineSeconds int
+	RetryPeriodSeconds   int
 }
 
 var options = PlacementRuleCMDOptions{
-	MetricsAddr: "",
-	KubeConfig:  "",
+	MetricsAddr:          "",
+	KubeConfig:           "",
+	LeaseDurationSeconds: 137,
+	RenewDeadlineSeconds: 107,
+	RetryPeriodSeconds:   26,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -45,5 +51,26 @@ func ProcessFlags() {
 		"kubeconfig",
 		options.KubeConfig,
 		"The kube config that points to a external api server.",
+	)
+
+	flag.IntVar(
+		&options.LeaseDurationSeconds,
+		"lease-duration",
+		options.LeaseDurationSeconds,
+		"The lease duration in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RenewDeadlineSeconds,
+		"renew-deadline",
+		options.RenewDeadlineSeconds,
+		"The renew deadline in seconds.",
+	)
+
+	flag.IntVar(
+		&options.RetryPeriodSeconds,
+		"retry-period",
+		options.RetryPeriodSeconds,
+		"The retry period in seconds.",
 	)
 }


### PR DESCRIPTION
Following recommended default settings of leaseDuration=137s, renewDeadline=107s, and retryPeriod=26s from https://github.com/openshift/library-go/blob/4b9033d00d37b88393f837a88ff541a56fd13621/pkg/config/leaderelection/leaderelection.go#L84


https://github.com/stolostron/backlog/issues/25245
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>