### PR TITLE
Prevent push triggered CI workflows from running on synced forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
+    if: ${{ github.repository.fork == false }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -19,6 +19,7 @@ jobs:
   images:
     name: images
     runs-on: ubuntu-latest
+    if: ${{ github.repository.fork == false }}
     steps:
       - name: checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Hey

Every time I sync my fork, the CI workflows: _fossa_ and _go-postsubmit_ are triggered and always fail.
I assume the lack of secrets is the main cause, regardless, these workflows can be set to run only for the original repo by adding the switch in this PR.

Here's a screenshot from my fork after rebasing and syncing it today:
![image](https://user-images.githubusercontent.com/28388442/188898675-132f0a10-3c93-4bec-bbd3-addf809548b1.png)
