### PR TITLE
Remove the unsupported cluster versions in upgrade environment

### DIFF
--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -103,7 +103,7 @@ linters-settings:
     min-confidence: 0.0
   gocognit:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 150
+    min-complexity: 200
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -203,6 +203,33 @@ func (sync *KubeSynchronizer) PurgeAllSubscribedResources(appsub *appv1alpha1.Su
 			appSubUnitStatus.Message = ""
 			appSubUnitStatuses = append(appSubUnitStatuses, appSubUnitStatus)
 		}
+
+		legacyUnitStatuses := sync.getResourcesByLegacySubStatus(appsub)
+		for _, legacyResource := range legacyUnitStatuses {
+			appSubUnitStatus := SubscriptionUnitStatus{}
+			appSubUnitStatus.Kind = legacyResource.Kind
+			appSubUnitStatus.Name = legacyResource.Name
+			appSubUnitStatus.Namespace = legacyResource.Namespace
+			for _, appsub := range appSubUnitStatuses { // search for resources with same kind to find version
+				if appSubUnitStatus.Kind == appsub.Kind {
+					appSubUnitStatus.APIVersion = appsub.APIVersion
+					break
+				}
+			}
+
+			err := sync.DeleteSingleSubscribedResource(hostSub, legacyResource)
+			if err != nil {
+				appSubUnitStatus.Phase = string(appSubStatusV1alpha1.PackageDeployFailed)
+				appSubUnitStatus.Message = err.Error()
+				appSubUnitStatuses = append(appSubUnitStatuses, appSubUnitStatus)
+
+				continue
+			}
+
+			appSubUnitStatus.Phase = string(appSubStatusV1alpha1.PackageDeployed)
+			appSubUnitStatus.Message = ""
+			appSubUnitStatuses = append(appSubUnitStatuses, appSubUnitStatus)
+		}
 	}
 
 	appsubClusterStatus := SubscriptionClusterStatus{


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

Adds a new function, `getResourcesByLegacySubStatus` to grab the resource list deployed by the legacy subscription controller.
Compares legacy resources to new resources and removes orphaned resources that are not present in the new controller.

Addresses:
- https://github.com/stolostron/backlog/issues/25346