### PR TITLE
Disable placementrule controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ cluster_config
 e2e/results
 
 test/unit
+
+vendor/

--- a/pkg/apis/apps/placementrule/v1/placementrule_types.go
+++ b/pkg/apis/apps/placementrule/v1/placementrule_types.go
@@ -148,3 +148,10 @@ type PlacementRuleList struct {
 func init() {
 	SchemeBuilder.Register(&PlacementRule{}, &PlacementRuleList{})
 }
+
+const (
+	// PlacementRuleDisableAnnotationkey is used to disable scheduling for a placementrule.
+	// It is an experimental flag to let placementrule controller ignore this placementrule,
+	// so other placementrule consumers can chime in.
+	PlacementRuleDisableAnnotationkey = "apps.open-cluster-management.io/experimental-controller-disable"
+)


### PR DESCRIPTION
introduce apps.open-cluster-management.io/placement-scheduling-disable annotation to allow disabling the scheduling. for example, in the global hub case, the global hub controller will propagate the placementrule to the regional hub cluster. the placementrule is not designed to run in the cluster where it was created. It is designed to run in the regional hub clusters.

ref: https://github.com/stolostron/backlog/issues/25857
Signed-off-by: clyang82 <chuyang@redhat.com>