### PR TITLE
Change lease-duration to leader-election-lease-duration

### DIFF
--- a/cmd/appsubsummary/exec/manager.go
+++ b/cmd/appsubsummary/exec/manager.go
@@ -63,7 +63,7 @@ func RunManager() {
 		}
 	}
 
-	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
 	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
 	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	// Create a new Cmd to provide shared dependencies and start components

--- a/cmd/appsubsummary/exec/options.go
+++ b/cmd/appsubsummary/exec/options.go
@@ -20,21 +20,21 @@ import (
 
 // AppSubStatusCMDOptions for command line flag parsing.
 type AppSubStatusCMDOptions struct {
-	MetricsAddr          string
-	KubeConfig           string
-	SyncInterval         int
-	LeaseDurationSeconds int
-	RenewDeadlineSeconds int
-	RetryPeriodSeconds   int
+	MetricsAddr                        string
+	KubeConfig                         string
+	SyncInterval                       int
+	LeaderElectionLeaseDurationSeconds int
+	RenewDeadlineSeconds               int
+	RetryPeriodSeconds                 int
 }
 
 var options = AppSubStatusCMDOptions{
-	MetricsAddr:          "",
-	KubeConfig:           "",
-	SyncInterval:         15,
-	LeaseDurationSeconds: 137,
-	RenewDeadlineSeconds: 107,
-	RetryPeriodSeconds:   26,
+	MetricsAddr:                        "",
+	KubeConfig:                         "",
+	SyncInterval:                       15,
+	LeaderElectionLeaseDurationSeconds: 137,
+	RenewDeadlineSeconds:               107,
+	RetryPeriodSeconds:                 26,
 }
 
 // ProcessFlags parses command line parameters into options.
@@ -63,10 +63,10 @@ func ProcessFlags() {
 	)
 
 	flag.IntVar(
-		&options.LeaseDurationSeconds,
-		"lease-duration",
-		options.LeaseDurationSeconds,
-		"The lease duration in seconds.",
+		&options.LeaderElectionLeaseDurationSeconds,
+		"leader-election-lease-duration",
+		options.LeaderElectionLeaseDurationSeconds,
+		"The leader election lease duration in seconds.",
 	)
 
 	flag.IntVar(

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -68,7 +68,7 @@ func RunManager() {
 	cfg.QPS = 30.0
 	cfg.Burst = 60
 
-	leaseDuration := time.Duration(options.LeaseDurationSeconds) * time.Second
+	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
 	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
 	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/cmd/placementrule/exec/options.go
+++ b/cmd/placementrule/exec/options.go
@@ -20,19 +20,19 @@ import (
 
 // PlacementRuleCMDOptions for command line flag parsing
 type PlacementRuleCMDOptions struct {
-	MetricsAddr          string
-	KubeConfig           string
-	LeaseDurationSeconds int
-	RenewDeadlineSeconds int
-	RetryPeriodSeconds   int
+	MetricsAddr                        string
+	KubeConfig                         string
+	LeaderElectionLeaseDurationSeconds int
+	RenewDeadlineSeconds               int
+	RetryPeriodSeconds                 int
 }
 
 var options = PlacementRuleCMDOptions{
-	MetricsAddr:          "",
-	KubeConfig:           "",
-	LeaseDurationSeconds: 137,
-	RenewDeadlineSeconds: 107,
-	RetryPeriodSeconds:   26,
+	MetricsAddr:                        "",
+	KubeConfig:                         "",
+	LeaderElectionLeaseDurationSeconds: 137,
+	RenewDeadlineSeconds:               107,
+	RetryPeriodSeconds:                 26,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -54,10 +54,10 @@ func ProcessFlags() {
 	)
 
 	flag.IntVar(
-		&options.LeaseDurationSeconds,
-		"lease-duration",
-		options.LeaseDurationSeconds,
-		"The lease duration in seconds.",
+		&options.LeaderElectionLeaseDurationSeconds,
+		"leader-election-lease-duration",
+		options.LeaderElectionLeaseDurationSeconds,
+		"The leader election lease duration in seconds.",
 	)
 
 	flag.IntVar(


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

While writing the [doc issue](https://github.com/stolostron/backlog/issues/25868) for https://github.com/stolostron/backlog/issues/25245 I noticed inconsistent naming of the lease duration flag. This change will keep the flag consistent for all the different parts of the controllers.