### PR TITLE
test: fix flaky test suite wrap ups

### DIFF
--- a/pkg/subscriber/git/git_subscriber_suite_test.go
+++ b/pkg/subscriber/git/git_subscriber_suite_test.go
@@ -92,6 +92,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	gexec.KillAndWait(5 * time.Second)
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, "30s", "5s").ShouldNot(HaveOccurred())
 })

--- a/pkg/subscriber/helmrepo/helmrepo_subscriber_suite_test.go
+++ b/pkg/subscriber/helmrepo/helmrepo_subscriber_suite_test.go
@@ -88,6 +88,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	gexec.KillAndWait(5 * time.Second)
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, "30s", "5s").ShouldNot(HaveOccurred())
 })

--- a/pkg/synchronizer/kubernetes/sync_suite_test.go
+++ b/pkg/synchronizer/kubernetes/sync_suite_test.go
@@ -99,6 +99,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	gexec.KillAndWait(5 * time.Second)
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, "30s", "5s").ShouldNot(HaveOccurred())
 })


### PR DESCRIPTION
Lately I've been experiencing some flakiness with the test suite wrap up functions, _AfterSuite_.
When stopping the testing environment between the different suits, occasionally an error will occur and break the assertions:
`timeout waiting for process kube-apiserver to stop`.

After snooping around online, I found using the _Eventually_ assertion to be a common solution for a common problem.
It, of course, fixed my issue as far as I can see.