### PR TITLE
chore: set git sub metric test example source to own repo

### DIFF
--- a/test/e2e/cases/19-verify-git-pull-time-metric/channel.yaml
+++ b/test/e2e/cases/19-verify-git-pull-time-metric/channel.yaml
@@ -5,6 +5,5 @@ metadata:
   name: gitops
   namespace: git-pull-time-metric-test
 spec:
-  # change to https://github.com/open-cluster-management-io/multicloud-operators-subscription after merge
-  pathname: https://github.com/TomerFi/ocm-playground
+  pathname: https://github.com/open-cluster-management-io/multicloud-operators-subscription
   type: git


### PR DESCRIPTION
Continuation of https://github.com/open-cluster-management-io/multicloud-operators-subscription/pull/261.

Issue: https://github.com/stolostron/backlog/issues/25649
