### PR TITLE
feat: added propagation_time histrogram metrics for hub clusters

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,8 +27,9 @@
   - [Managed Cluster Metrics Service Missing](#managed-cluster-metrics-service-missing)
   - [Standalone Cluster Metrics Service Missing](#standalone-cluster-metrics-service-missing)
 - [Custom Metrics](#custom-metrics)
+  - [Hub Cluster Custom Metrics](#hub-cluster-custom-metrics)
   - [Managed Cluster Custom Metrics](#managed-cluster-custom-metrics)
-    - [Collecting Managed Cluster Metrics for Observability](#collecting-managed-cluster-metrics-for-observability)
+  - [Collecting Custom Metrics for Observability](#collecting-custom-metrics-for-observability)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -282,7 +283,7 @@ EOF
 Create a *Role* for setting the permissions for monitoring:
 
 ```shell
-cat << EOF | oc --context kind-managed1 apply -f -
+cat << EOF | oc apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -536,6 +537,23 @@ EOF
 
 Adding to the [default exported metrics by the controller-runtime](https://book.kubebuilder.io/reference/metrics-reference.html#default-exported-metrics-references).
 
+## Hub Cluster Custom Metrics
+
+The following metrics can be scrapped from *Hub Cluster*:
+
+| Name                        | Help                                        |
+| --------------------------- | ------------------------------------------- |
+| propagation_successful_time | Histogram of successful propagation latency |
+| propagation_failed_time     | Histogram of failed propagation latency     |
+
+> Note, for standalone deployments, no propagation occurs, therefore no propagation metrics will be observed.
+
+Common vector labels:
+
+- *subscription_type*
+- *subscription_namespace*
+- *subscription_name*
+
 ## Managed Cluster Custom Metrics
 
 The following metrics can be scrapped from *Managed Clusters*:
@@ -551,9 +569,9 @@ Common vector labels:
 - *subscription_namespace*
 - *subscription_name*
 
-### Collecting Managed Cluster Metrics for Observability
+## Collecting Custom Metrics for Observability
 
-For the [Observability Operator](https://github.com/stolostron/multicluster-observability-operator) to collect the aforementioned metrics from the *Managed Clusters*, you need to configure the `observability-metrics-custom-allowlist` *ConfigMap* in the `open-cluster-management-observability` namespace on the *Hub Cluster*.</br>
+For the [Observability Operator](https://github.com/stolostron/multicluster-observability-operator) to collect the aforementioned metrics, we need to configure the `observability-metrics-custom-allowlist` *ConfigMap* in the `open-cluster-management-observability` namespace on the *Hub Cluster*.</br>
 Note that for *Histogram* type metrics, we have a 3 metrics series created per each *Histogram*, the members of the series are identified by the *bucket*, *count*, and *sum* suffixes to the metric name. Here's an example of a working *ConfigMap*:
 
 ```yaml
@@ -568,4 +586,10 @@ data:
     - git_failed_pull_time_bucket
     - git_failed_pull_time_count
     - git_failed_pull_time_sum
+    - propagation_successful_time_bucket
+    - propagation_successful_time_count
+    - propagation_successful_time_sum
+    - propagation_failed_time_bucket
+    - propagation_failed_time_count
+    - propagation_failed_time_sum
 ```

--- a/pkg/utils/metrics/hub/hub_cluster_metrics.go
+++ b/pkg/utils/metrics/hub/hub_cluster_metrics.go
@@ -1,0 +1,35 @@
+// Copyright 2021 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ocmMetrics "open-cluster-management.io/multicloud-operators-subscription/pkg/utils/metrics"
+	controllerMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var PropagationSuccessfulPullTime = *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "propagation_successful_time",
+	Help: "Histogram of successful propagation latency",
+}, ocmMetrics.SubscriptionVectorLabels)
+
+var PropagationFailedPullTime = *prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "propagation_failed_time",
+	Help: "Histogram of failed propagation latency",
+}, ocmMetrics.SubscriptionVectorLabels)
+
+func init() {
+	controllerMetrics.Registry.MustRegister(PropagationSuccessfulPullTime, PropagationFailedPullTime)
+}

--- a/test/e2e/cases/20-verify-propagation-time-metric/common/00-namespace.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/common/00-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: propagation-time-metric-test

--- a/test/e2e/cases/20-verify-propagation-time-metric/common/channel.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/common/channel.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: gitops
+  namespace: propagation-time-metric-test
+spec:
+  pathname: https://github.com/open-cluster-management-io/multicloud-operators-subscription
+  type: git

--- a/test/e2e/cases/20-verify-propagation-time-metric/common/clusterset.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/common/clusterset.yaml
@@ -1,0 +1,4 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSet
+metadata:
+  name: app-demo

--- a/test/e2e/cases/20-verify-propagation-time-metric/common/clustersetbinding.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/common/clustersetbinding.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: app-demo
+  namespace: propagation-time-metric-test
+spec:
+  clusterSet: app-demo

--- a/test/e2e/cases/20-verify-propagation-time-metric/common/placement.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/common/placement.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: app-demo-placement
+  namespace: propagation-time-metric-test
+spec:
+  numberOfClusters: 1
+  clusterSets:
+    - app-demo
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            purpose: test

--- a/test/e2e/cases/20-verify-propagation-time-metric/failed-no-placement/subscription.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/failed-no-placement/subscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: examples/git-simple-sub
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: propagation-fail-no-pl-time-metric-sub
+  namespace: propagation-time-metric-test
+spec:
+  channel: propagation-time-metric-test/gitops

--- a/test/e2e/cases/20-verify-propagation-time-metric/failed-placement-wrong/subscription.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/failed-placement-wrong/subscription.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: examples/git-simple-sub
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: propagation-fail-pl-wrong-time-metric-sub
+  namespace: propagation-time-metric-test
+spec:
+  channel: propagation-time-metric-test/gitnotops
+  placement:
+    local: true
+    placementRef:
+      kind: Placement
+      name: app-demo-placement

--- a/test/e2e/cases/20-verify-propagation-time-metric/standalone/subscription.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/standalone/subscription.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: examples/git-simple-sub
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: standalone-sub-no-metric
+  namespace: propagation-time-metric-test
+spec:
+  channel: propagation-time-metric-test/gitops
+  placement:
+    local: true

--- a/test/e2e/cases/20-verify-propagation-time-metric/successful/subscription.yaml
+++ b/test/e2e/cases/20-verify-propagation-time-metric/successful/subscription.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: examples/git-simple-sub
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: propagation-successful-time-metric-sub
+  namespace: propagation-time-metric-test
+spec:
+  channel: propagation-time-metric-test/gitops
+  placement:
+    placementRef:
+      kind: Placement
+      name: app-demo-placement


### PR DESCRIPTION
Added the following custom metrics to the _Hub Cluster_:

| Name                        | Help                                        |
| --------------------------- | ------------------------------------------- |
| propagation_successful_time | Histogram of successful propagation latency |
| propagation_failed_time     | Histogram of failed propagation latency     |

> Not applicable for standalone deployments.

Issue: https://github.com/stolostron/backlog/issues/25649