### PR TITLE
subscription csv bundle format issue

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -880,13 +880,13 @@ spec:
                 emptyDir: {}
               - name: multicluster-operators-subscription-tls
                 secret:
-                defaultMode: 420
-                secretName: multicluster-operators-subscription
-                items:
-                - key: tls.crt
-                  path: tls.crt
-                - key: tls.key
-                  path: tls.key
+                  defaultMode: 420
+                  secretName: multicluster-operators-subscription
+                  items:
+                  - key: tls.crt
+                    path: tls.crt
+                  - key: tls.key
+                    path: tls.key
               serviceAccountName: multicluster-operators
       - name: multicluster-operators-hub-subscription
         spec:
@@ -976,13 +976,13 @@ spec:
                 emptyDir: {}
               - name: multicluster-operators-subscription-tls
                 secret:
-                defaultMode: 420
-                secretName: multicluster-operators-subscription
-                items:
-                - key: tls.crt
-                  path: tls.crt
-                - key: tls.key
-                  path: tls.key
+                  defaultMode: 420
+                  secretName: multicluster-operators-subscription
+                  items:
+                  - key: tls.crt
+                    path: tls.crt
+                  - key: tls.key
+                    path: tls.key
               serviceAccountName: multicluster-operators
     strategy: deployment
   installModes:


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The fix is to address the the csv indent issues reported by the installer squad.  It caused the installer k8s validation failure when pulling the two relative deployment resources from the csv.