### PR TITLE
Display default values in advanced-cluster-management csv

### DIFF
--- a/addon/manifests/chart/templates/deployment.yaml
+++ b/addon/manifests/chart/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
           - "--alsologtostderr"
           - "--cluster-name={{ .Values.clusterName }}"
           - "--hub-cluster-configfile=/var/run/klusterlet/kubeconfig"
+          - "--leader-election-lease-duration=137"
+          - "--renew-deadline=107"
+          - "--retry-period=26"
         livenessProbe:
           exec:
             command:

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -495,6 +495,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-placementrule
                 - --alsologtostderr
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -537,6 +540,9 @@ spec:
               - command:
                 - /usr/local/bin/gitopscluster
                 - --alsologtostderr
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -579,6 +585,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-application
                 - --alsologtostderr
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 ports:
                 - containerPort: 9442
                   name: app-whk-server
@@ -665,6 +674,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-channel
                 - --alsologtostderr
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 ports:
                 - containerPort: 9443            
                   name: chn-whk-server
@@ -750,6 +762,9 @@ spec:
               containers:
               - command:
                 - /usr/local/bin/appsubsummary
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -833,6 +848,9 @@ spec:
                 - /usr/local/bin/multicluster-operators-subscription
                 - --standalone
                 - --sync-interval=60
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -920,6 +938,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-subscription
                 - --sync-interval=60
+                - --leader-election-lease-duration=137
+                - --renew-deadline=107
+                - --retry-period=26
                 ports:
                 - containerPort: 8443            
                 env:


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

This change is for displaying the default values for leader-election-lease-duration, renew-deadline, and retry-period in the "advanced-cluster-management" CSV of all 7 controllers. Following the default values as suggested by the communities best practice.

Addresses:
 - https://issues.redhat.com/browse/ACM-2073