### PR TITLE
chore: added olm servicemonitor manifests for the metrics services

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -66,6 +66,10 @@ metadata:
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
+    required:
+    - name: monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
     owned:
     - description: Subscribe resources from a channel according to its package filters
       displayName: App Subscription

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/role_promethues_monitoring.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/role_promethues_monitoring.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s-monitoring
+  namespace: open-cluster-management
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/rolebinding_promethues_monitoring.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/rolebinding_promethues_monitoring.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s-monitoring
+  namespace: open-cluster-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s-monitoring
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/servicemonitor_hub_metrics_service.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/servicemonitor_hub_metrics_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hub-subscription-metrics
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - open-cluster-management
+  selector:
+    matchLabels:
+      app: hub-subscription-metrics

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/servicemonitor_standalone_metrics_service.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/servicemonitor_standalone_metrics_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: standalone-subscription-metrics
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - open-cluster-management
+  selector:
+    matchLabels:
+      app: standalone-subscription-metrics


### PR DESCRIPTION
- Added _ServiceMonitor_ manifests for the _OLM Catalog_.
- Included _ServiceMonitor_ as a required _CRD_ for the operator _CSV_.
- ~~Updated metrics docs for clarification (removed unrelated misleading observability section).~~

> ~~_OLM_ manifests does not include the required _RBAC_ for collecting the metrics by _Promethues_'s _ServiceAccount_.~~

EDIT:
- Added _Role_ and _RoleBinding_ resources to allow _Promethues_ to scrap the new metric services.

issue: https://github.com/stolostron/backlog/issues/25649