### PR TITLE
Enforce server side TLSv1.2

### DIFF
--- a/cmd/appsubsummary/exec/manager.go
+++ b/cmd/appsubsummary/exec/manager.go
@@ -27,6 +27,7 @@ import (
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -76,6 +77,7 @@ func RunManager() {
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,
 		RetryPeriod:             &retryPeriod,
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 	if err != nil {
 		klog.Error(err, "")

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -43,6 +43,7 @@ import (
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/synchronizer"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/webhook"
+	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -114,6 +115,7 @@ func RunManager() {
 		LeaseDuration:           &leaderElectionLeaseDuration,
 		RenewDeadline:           &renewDeadline,
 		RetryPeriod:             &retryPeriod,
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 
 	if err != nil {

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	k8swebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -80,6 +81,7 @@ func RunManager() {
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,
 		RetryPeriod:             &retryPeriod,
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 
 	if err != nil {

--- a/pkg/webhook/listener/webhook_listener_test.go
+++ b/pkg/webhook/listener/webhook_listener_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -443,4 +443,24 @@ func TestServiceCreation(t *testing.T) {
 	err = createWebhookListnerService(c, "default")
 	// It will fail because the deployment resource for the owner reference is not found in the cluster.
 	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestWebhookListener_Start(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Setup the Manager and Controller
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c = mgr.GetClient()
+
+	Add(mgr, cfg, "", "", true, false) // starting webhook server on port 8443 with no TLS
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
 }


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

PR enforces TLSv1.2 and confirmed using nmap script ssl-enum-ciphers:

Before enforcement:
```
| ssl-enum-ciphers: 
|   TLSv1.0: 
|     ciphers: 
|       ...
|   TLSv1.1: 
|     ciphers: 
|       ...
|   TLSv1.2: 
|     ciphers: 
|       ...
```

After enforcement:

```
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       ...
```

PR uses a similar approach to https://github.com/stolostron/clusterlifecycle-state-metrics/pull/90 in handling the TLS version of the webhook listener server.

Addresses:
 - https://github.com/stolostron/backlog/issues/26685