### PR TITLE
chore: added missing olm manifest for a servicemonitor for the mc metrics

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/servicemonitor_mc_metrics_service.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/servicemonitor_mc_metrics_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mc-subscription-metrics
+  namespace: openshift-monitoring
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - open-cluster-management
+  selector:
+    matchLabels:
+      app: mc-subscription-metrics


### PR DESCRIPTION
- added missing _OLM_ manifest for a _ServiceMonitor_ for the spoke metric service.

continuation of: https://github.com/open-cluster-management-io/multicloud-operators-subscription/pull/283
issue: https://github.com/stolostron/backlog/issues/25649