### PR TITLE
Fix sshKey typo in error message

### DIFF
--- a/pkg/subscriber/git/git_subscriber_test.go
+++ b/pkg/subscriber/git/git_subscriber_test.go
@@ -376,7 +376,7 @@ var _ = Describe("test subscribe invalid resource", func() {
 
 		subitem.SubscriberItem.ChannelSecret = chnIncorrectSecret
 		_, err = subitem.cloneGitRepo()
-		Expect(err.Error()).To(Equal("ssh_key (and optionally passphrase) or user and accressToken need to be specified in the channel secret"))
+		Expect(err.Error()).To(Equal("sshKey (and optionally passphrase) or user and accressToken need to be specified in the channel secret"))
 
 		chnIncorrectSecret2 := &corev1.Secret{}
 		err = yaml.Unmarshal([]byte(incorrectSecret2), &chnIncorrectSecret2)
@@ -384,7 +384,7 @@ var _ = Describe("test subscribe invalid resource", func() {
 		subitem.SubscriberItem.ChannelSecret = chnIncorrectSecret2
 
 		_, err = subitem.cloneGitRepo()
-		Expect(err.Error()).To(Equal("ssh_key (and optionally passphrase) or user and accressToken need to be specified in the channel secret"))
+		Expect(err.Error()).To(Equal("sshKey (and optionally passphrase) or user and accressToken need to be specified in the channel secret"))
 
 		err = k8sClient.Delete(context.TODO(), chnSecret)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -78,7 +78,7 @@ type kubeResource struct {
 	Kind       string `yaml:"kind"`
 }
 
-//KKubeResource export the kuKubeResource for other package
+// KKubeResource export the kuKubeResource for other package
 type KubeResource struct {
 	kubeResource
 }
@@ -701,7 +701,7 @@ func ParseChannelSecret(secret *corev1.Secret) (string, string, []byte, []byte, 
 		if username == "" || accessToken == "" {
 			klog.Error(err, "sshKey (and optionally passphrase) or user and accressToken need to be specified in the channel secret")
 			return username, accessToken, sshKey, passphrase, clientKey, clientCert,
-				errors.New("ssh_key (and optionally passphrase) or user and accressToken need to be specified in the channel secret")
+				errors.New("sshKey (and optionally passphrase) or user and accressToken need to be specified in the channel secret")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

Managed to locate the only locations of the `ssh_key` typo and replace with the proper value `sshKey`.

Addresses:
 - https://github.com/stolostron/backlog/issues/26909