### PR TITLE
increase placementrule memory limit to 1.5G for 3K clusters case

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -530,7 +530,7 @@ spec:
                 resources:
                   limits:
                     cpu: 1500m
-                    memory: 512Mi
+                    memory: 1.5Gi
                   requests:
                     cpu: 300m
                     memory: 64Mi


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

With ~2000 placementrule created In the 3K managed cluster test case,  the actual memory usage of the placementrule container is increased to >700M. The fix is to set the memory limit to 1.5G to make sure no OOM killed issue will happen
```
# oc adm top pod -n open-cluster-management multicluster-operators-application-77866bb646-4zb5h --containers
POD                                                   NAME                                   CPU(cores)   MEMORY(bytes)   
multicluster-operators-application-77866bb646-4zb5h   POD                                    0m           0Mi             
multicluster-operators-application-77866bb646-4zb5h   multicluster-operators-application     5m           27Mi            
multicluster-operators-application-77866bb646-4zb5h   multicluster-operators-gitopscluster   7m           77Mi            
multicluster-operators-application-77866bb646-4zb5h   multicluster-operators-placementrule   1050m        704Mi    
```