### PR TITLE
add liveness probe to managed cluster subscription controller

### DIFF
--- a/addon/manifests/chart/templates/deployment.yaml
+++ b/addon/manifests/chart/templates/deployment.yaml
@@ -47,11 +47,11 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         livenessProbe:
-          exec:
-            command:
-            - ls
-          initialDelaySeconds: 15
-          periodSeconds: 15
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 2
+          periodSeconds: 10
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://issues.redhat.com/browse/ACM-2326

To align with other addon deployment, we migrated the hub kubeconfig check to healthz liveness probe. As such we removed the old way - exit controller directly if there is hub kubeconfig change detected. Also the lease update per minute is reverted  to run in a separate go routine.