### PR TITLE
check if appsubstatus resouce lit empty to avoid panic error

### DIFF
--- a/pkg/synchronizer/kubernetes/sync_appsubstatus.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus.go
@@ -652,6 +652,12 @@ func getClusterAppsubReport(rClient client.Client, clusterAppsubReportNs string,
 
 func shouldSkip(appsubClusterStatus SubscriptionClusterStatus, foundPkgStatus bool,
 	pkgstatus v1alpha1.SubscriptionStatus) bool {
+	if len(pkgstatus.Statuses.SubscriptionStatus) == 0 {
+		klog.Infof("appsubstatus resouse list is empty, appsubstatus: %v/%v", pkgstatus.Namespace, pkgstatus.Name)
+
+		return false
+	}
+
 	if len(appsubClusterStatus.SubscriptionPackageStatus) == 1 &&
 		strings.EqualFold(appsubClusterStatus.SubscriptionPackageStatus[0].Kind, "HelmRelease") &&
 		strings.EqualFold(appsubClusterStatus.SubscriptionPackageStatus[0].APIVersion, "apps.open-cluster-management.io/v1") &&

--- a/pkg/synchronizer/kubernetes/sync_appsubstatus_test.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus_test.go
@@ -550,5 +550,15 @@ var _ = Describe("test create/update/delete appsub status for standalone and man
 		err = s.SyncAppsubClusterStatus(appsubToBeDeleted, rmClusterStatus, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
+		// shouldSkip should return false when there is appsubstatus with empty status
+		emptyAppsubStatus := appSubStatusV1alpha1.SubscriptionStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "appsubstatus-1",
+				Namespace: "default",
+			},
+			Statuses: appSubStatusV1alpha1.SubscriptionClusterStatusMap{},
+		}
+
+		Expect(shouldSkip(appsubClusterStatus, true, emptyAppsubStatus)).To(BeFalse())
 	})
 })

--- a/pkg/synchronizer/kubernetes/synchronizer_test.go
+++ b/pkg/synchronizer/kubernetes/synchronizer_test.go
@@ -749,6 +749,7 @@ var _ = Describe("test cleanup of resources", func() {
 		}
 
 		Expect(k8sClient.Create(context.TODO(), appSubStatus)).NotTo(HaveOccurred())
+		time.Sleep(8 * time.Second)
 		Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: "appsub-ns-1", Name: "appsubstatus-1"}, appSubStatus)).NotTo(HaveOccurred())
 		defer k8sClient.Delete(context.TODO(), appSubStatus)
 


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://issues.redhat.com/browse/ACM-2519

The fix is to address one urgent customer issue.

There is a pre-existing appsubstatus CR with empty resource list on the hub cluster for some reason. It caused the panic failure in function shouldSkip when handling a chart appsub deployment, as the foundPkgStatus is true but there is no resource list in the appsubStatus (pkgstatus.Statuses.SubscriptionStatus)

https://github.com/open-cluster-management-io/multicloud-operators-subscription/blob/768867c3225da13707d4e4e1d29facf91c8cd858/pkg/synchronizer/kubernetes/sync_appsubstatus.go#L660
