### PR TITLE
ACM-2536: Placement rule not matching

### DIFF
--- a/pkg/placementrule/utils/cluster.go
+++ b/pkg/placementrule/utils/cluster.go
@@ -38,9 +38,25 @@ const (
 
 // ClusterPredicateFunc defines predicate function for cluster related watch, main purpose is to ignore heartbeat without change
 var ClusterPredicateFunc = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		newManagedCluster, ok := e.Object.(*spokeClusterV1.ManagedCluster)
+
+		if !ok {
+			return false
+		}
+
+		klog.Infof("new managed cluster created, %v/%v", newManagedCluster.Namespace, newManagedCluster.Name)
+
+		return true
+	},
+
 	UpdateFunc: func(e event.UpdateEvent) bool {
-		oldcl := e.ObjectOld.(*spokeClusterV1.ManagedCluster)
-		newcl := e.ObjectNew.(*spokeClusterV1.ManagedCluster)
+		oldcl, oldOK := e.ObjectOld.(*spokeClusterV1.ManagedCluster)
+		newcl, newOK := e.ObjectNew.(*spokeClusterV1.ManagedCluster)
+
+		if !oldOK || !newOK {
+			return false
+		}
 
 		//if managed cluster is being deleted
 		if !reflect.DeepEqual(oldcl.DeletionTimestamp, newcl.DeletionTimestamp) {


### PR DESCRIPTION
Signed-off-by: Maggie Chen <magchen@redhat.com>

https://issues.redhat.com/browse/ACM-2536

The placementrule controller is not reconciled when there is new managed cluster imported