### PR TITLE
Add multiclusterapplicationsetreport crd & update gitopscluster crd

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_gitopsclusters_crd_v1beta1.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_gitopsclusters_crd_v1beta1.yaml
@@ -158,6 +158,8 @@ spec:
                 required:
                 - argoNamespace
                 type: object
+              enablePullModel:
+                type: boolean
               placementRef:
                 description: 'ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
@@ -1,0 +1,108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: multiclusterapplicationsetreports.apps.open-cluster-management.io
+spec:
+  group: apps.open-cluster-management.io
+  names:
+    kind: MulticlusterApplicationSetReport
+    listKind: MulticlusterApplicationSetReportList
+    plural: multiclusterapplicationsetreports
+    shortNames:
+    - appsetreport
+    - appsetreports
+    singular: multiclusterapplicationsetreport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MulticlusterApplicationSetReport is the Schema for the MulticlusterApplicationSetReport
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          statuses:
+            description: AppConditions defines all the error/warning conditions in
+              all clusters per application
+            properties:
+              clusterConditions:
+                items:
+                  description: ClusterCondition defines all the error/warning conditions
+                    in one cluster per application
+                  properties:
+                    cluster:
+                      type: string
+                    conditions:
+                      items:
+                        description: Condition defines a type of error/warning
+                        properties:
+                          message:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                    healthStatus:
+                      type: string
+                    syncStatus:
+                      type: string
+                  type: object
+                type: array
+              resources:
+                items:
+                  description: ResourceRef defines a kind of resource
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              summary:
+                description: Summary provides a summary of results
+                properties:
+                  clusters:
+                    description: Clusters provides the count of all managed clusters
+                      the application is deployed to
+                    type: string
+                  healthy:
+                    description: Healthy provides the count of healthy applications
+                    type: string
+                  inProgress:
+                    description: InProgress provides the count of applications that
+                      are in the process of being deployed
+                    type: string
+                  notHealthy:
+                    description: NotHealthy provides the count of non-healthy applications
+                    type: string
+                  notSynced:
+                    description: NotSynced provides the count of the out of sync applications
+                    type: string
+                  synced:
+                    description: Synced provides the count of synced applications
+                    type: string
+                type: object
+            type: object
+        required:
+        - metadata
+        type: object
+    served: true
+    storage: true

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -184,6 +184,12 @@ spec:
       kind: Application
       name: applications.app.k8s.io
       version: v1beta1
+    - descrition: Represent a report of the aggregate status per applicationSet.
+      displayName: MulticlusterApplicationSetReport
+      group: apps.open-cluster-management.io
+      kind: MulticlusterApplicationSetReport
+      name: multiclusterapplicationsetreports.apps.open-cluster-management.io
+      version: v1alpha1
   description: |
     A multicluster subscription operator subscribes resources from multiple types of Channels and get them deployed to multiple managed clusters
     ## Prerequisites
@@ -359,7 +365,9 @@ spec:
           - subscriptions/finalizers
           - subscriptions/status          
           - subscriptionstatuses
-          - subscriptionreports             
+          - subscriptionreports
+          - multiclusterapplicationsetreports
+          - multiclusterapplicationsetreports/status
         - verbs:
           - get
           - list
@@ -456,6 +464,216 @@ spec:
           - deployments/finalizers
         serviceAccountName: multicluster-applications
       deployments:
+      - name: argocd-pull-integration-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              creationTimestamp: null
+              labels:
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+                imagePullPolicy: IfNotPresent
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /usr/local/bin/propagation
+                image: quay.io/stolostron/multicloud-integrations:2.8.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                    scheme: HTTP
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                name: manager
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                    scheme: HTTP
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 1
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              dnsPolicy: ClusterFirst
+              restartPolicy: Always
+              schedulerName: default-scheduler
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: multicluster-applications
+      - name: multicluster-integrations
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: multicluster-integrations
+          template:
+            metadata:
+              labels:
+                name: multicluster-integrations
+            spec:
+              containers:
+              - name: multicluster-integrations-syncresource
+                image: quay.io/stolostron/multicloud-integrations:2.8.0
+                imagePullPolicy: IfNotPresent
+                command:
+                - /usr/local/bin/gitopssyncresc
+                - --appset-resource-dir=/etc/gitops-resources
+                env:
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: DEPLOYMENT_LABEL
+                  value: multicluster-integrations-syncresource
+                - name: OPERATOR_NAME
+                  value: multicluster-integrations
+                livenessProbe:
+                  exec:
+                    command:
+                    - ls
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                readinessProbe:
+                  exec:
+                    command:
+                    - ls
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                  requests:
+                    cpu: 25m
+                    memory: 64Mi
+                volumeMounts:
+                - mountPath: /etc/gitops-resources
+                  name: multicluster-integrations-syncresource
+                  readOnly: false
+              - name: multicluster-integrations-aggregation
+                image: quay.io/stolostron/multicloud-integrations:2.8.0
+                imagePullPolicy: IfNotPresent
+                command:
+                - /usr/local/bin/multiclusterstatusaggregation
+                - --appset-resource-dir=/etc/gitops-resources
+                env:
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: DEPLOYMENT_LABEL
+                  value: multicluster-integrations-aggregation
+                - name: OPERATOR_NAME
+                  value: multicluster-integrations
+                livenessProbe:
+                  exec:
+                    command:
+                    - ls
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                readinessProbe:
+                  exec:
+                    command:
+                    - ls
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                  requests:
+                    cpu: 25m
+                    memory: 64Mi
+                volumeMounts:
+                - mountPath: /etc/gitops-resources
+                  name: multicluster-integrations-syncresource
+                  readOnly: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: multicluster-applications
+              volumes:
+              - name: multicluster-integrations-syncresource 
+                emptyDir: {}
       - name: multicluster-operators-application
         spec:
           replicas: 1


### PR DESCRIPTION
This PR adds the new `multiclusterapplicationsetreports` crd and updates the gitsopscluster crd to include the `enablePullModel` flag.

Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>
