### PR TITLE
Update csv for single deployment with 3 controllers

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -464,71 +464,27 @@ spec:
           - deployments/finalizers
         serviceAccountName: multicluster-applications
       deployments:
-      - name: argocd-pull-integration-controller-manager
+      - name: multicluster-integrations
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              name: multicluster-integrations
           template:
             metadata:
-              annotations:
-                kubectl.kubernetes.io/default-container: manager
-              creationTimestamp: null
               labels:
-                control-plane: controller-manager
+                name: multicluster-integrations
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: kubernetes.io/arch
-                        operator: In
-                        values:
-                        - amd64
-                        - arm64
-                        - ppc64le
-                        - s390x
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                        - linux
               containers:
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+              - name: argocd-pull-integration-controller-manager
+                image: quay.io/stolostron/multicloud-integrations:2.8.0
                 imagePullPolicy: IfNotPresent
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-                terminationMessagePath: /dev/termination-log
-                terminationMessagePolicy: File
-              - args:
+                args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 command:
                 - /usr/local/bin/propagation
-                image: quay.io/stolostron/multicloud-integrations:2.8.0
-                imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 3
                   httpGet:
@@ -539,7 +495,6 @@ spec:
                   periodSeconds: 20
                   successThreshold: 1
                   timeoutSeconds: 1
-                name: manager
                 readinessProbe:
                   failureThreshold: 3
                   httpGet:
@@ -564,24 +519,6 @@ spec:
                     - ALL
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
-              dnsPolicy: ClusterFirst
-              restartPolicy: Always
-              schedulerName: default-scheduler
-              securityContext:
-                runAsNonRoot: true
-              serviceAccountName: multicluster-applications
-      - name: multicluster-integrations
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: multicluster-integrations
-          template:
-            metadata:
-              labels:
-                name: multicluster-integrations
-            spec:
-              containers:
               - name: multicluster-integrations-syncresource
                 image: quay.io/stolostron/multicloud-integrations:2.8.0
                 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR updates the csv to have just a single deployment with 3 controllers deployed in the same pod, `multicluster-integrations`

Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>
