### PR TITLE
declare seccompProfile to avoid appsub pod failure in crun enabled OC…

### DIFF
--- a/addon/manifests/chart/templates/deployment.yaml
+++ b/addon/manifests/chart/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         component: "application-manager"
     spec:
       serviceAccountName: {{ template "application-manager.fullname" . }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: subscription-controller
         image: "{{ .Values.global.imageOverrides.multicluster_operators_subscription }}"

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -805,6 +805,8 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
@@ -978,6 +980,8 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
@@ -1069,6 +1073,8 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
…P cluster

https://issues.redhat.com/browse/ACM-4587?focusedId=22049389&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22049389

https://issues.redhat.com/browse/ACM-4589?focusedId=22057082&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22057082

Declare seccompProfile with default values in hub subscription pod, standalone subscription pod and application manager pod.

The seccompProfile default value has been confirmed to support in OCP 4.10, 4.11 and 4.12 as well.

