### PR TITLE
Update leader election settings

### DIFF
--- a/addon/manifests/chart/templates/deployment.yaml
+++ b/addon/manifests/chart/templates/deployment.yaml
@@ -75,9 +75,9 @@ spec:
           - "--alsologtostderr"
           - "--cluster-name={{ .Values.clusterName }}"
           - "--hub-cluster-configfile=/var/run/klusterlet/kubeconfig"
-          - "--leader-election-lease-duration=137"
-          - "--renew-deadline=107"
-          - "--retry-period=26"
+          - "--leader-election-lease-duration=137s"
+          - "--leader-election-renew-deadline=107s"
+          - "--leader-election-retry-period=26s"
         volumeMounts:
           - name: klusterlet-config
             mountPath: /var/run/klusterlet

--- a/cmd/appsubsummary/exec/manager.go
+++ b/cmd/appsubsummary/exec/manager.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
@@ -66,9 +65,11 @@ func RunManager() {
 		}
 	}
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -76,9 +77,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-appsubsummary-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 		ClientDisableCacheFor:   []client.Object{&corev1.Secret{}, &corev1.ServiceAccount{}},
 	})

--- a/cmd/appsubsummary/exec/options.go
+++ b/cmd/appsubsummary/exec/options.go
@@ -15,26 +15,28 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // AppSubStatusCMDOptions for command line flag parsing.
 type AppSubStatusCMDOptions struct {
-	MetricsAddr                        string
-	KubeConfig                         string
-	SyncInterval                       int
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	KubeConfig                  string
+	SyncInterval                int
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = AppSubStatusCMDOptions{
-	MetricsAddr:                        "",
-	KubeConfig:                         "",
-	SyncInterval:                       15,
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	KubeConfig:                  "",
+	SyncInterval:                15,
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 // ProcessFlags parses command line parameters into options.
@@ -62,24 +64,31 @@ func ProcessFlags() {
 		"The kube config that points to a external api server.",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -110,9 +110,11 @@ func RunManager() {
 	cfg.QPS = 100.0
 	cfg.Burst = 200
 
-	leaderElectionLeaseDuration := time.Duration(Options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(Options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(Options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", Options.LeaderElectionLeaseDuration,
+		"renewDeadline", Options.LeaderElectionRenewDeadline,
+		"retryPeriod", Options.LeaderElectionRetryPeriod)
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
@@ -120,9 +122,9 @@ func RunManager() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        leaderElectionID,
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaderElectionLeaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &Options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &Options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &Options.LeaderElectionRetryPeriod,
 		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 		ClientDisableCacheFor:   []client.Object{&corev1.Secret{}, &corev1.ServiceAccount{}},
 	})

--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -15,40 +15,42 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // SubscriptionCMDOptions for command line flag parsing
 type SubscriptionCMDOptions struct {
-	MetricsAddr                        string
-	KubeConfig                         string
-	ClusterName                        string
-	HubConfigFilePathName              string
-	TLSKeyFilePathName                 string
-	TLSCrtFilePathName                 string
-	SyncInterval                       int
-	DisableTLS                         bool
-	Standalone                         bool
-	AgentImage                         string
-	LeaseDurationSeconds               int
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
-	Debug                              bool
-	AgentInstallAll                    bool
+	MetricsAddr                 string
+	KubeConfig                  string
+	ClusterName                 string
+	HubConfigFilePathName       string
+	TLSKeyFilePathName          string
+	TLSCrtFilePathName          string
+	SyncInterval                int
+	DisableTLS                  bool
+	Standalone                  bool
+	AgentImage                  string
+	LeaseDurationSeconds        int
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
+	Debug                       bool
+	AgentInstallAll             bool
 }
 
 var Options = SubscriptionCMDOptions{
-	MetricsAddr:                        "",
-	KubeConfig:                         "",
-	SyncInterval:                       60,
-	LeaseDurationSeconds:               60,
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
-	Standalone:                         false,
-	AgentImage:                         "quay.io/open-cluster-management/multicloud-operators-subscription:latest",
-	Debug:                              false,
+	MetricsAddr:                 "",
+	KubeConfig:                  "",
+	SyncInterval:                60,
+	LeaseDurationSeconds:        60,
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
+	Standalone:                  false,
+	AgentImage:                  "quay.io/open-cluster-management/multicloud-operators-subscription:latest",
+	Debug:                       false,
 }
 
 // ProcessFlags parses command line parameters into Options
@@ -97,25 +99,32 @@ func ProcessFlags() {
 		"The lease duration in seconds.",
 	)
 
-	flag.IntVar(
-		&Options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&Options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		Options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		Options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&Options.RenewDeadlineSeconds,
-		"renew-deadline",
-		Options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&Options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		Options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&Options.RetryPeriodSeconds,
-		"retry-period",
-		Options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&Options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		Options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 
 	flag.BoolVar(

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/placementrule/controller"
@@ -69,18 +68,20 @@ func RunManager() {
 	cfg.QPS = 30.0
 	cfg.Burst = 60
 
-	leaseDuration := time.Duration(options.LeaderElectionLeaseDurationSeconds) * time.Second
-	renewDeadline := time.Duration(options.RenewDeadlineSeconds) * time.Second
-	retryPeriod := time.Duration(options.RetryPeriodSeconds) * time.Second
+	klog.Info("Leader election settings",
+		"leaseDuration", options.LeaderElectionLeaseDuration,
+		"renewDeadline", options.LeaderElectionRenewDeadline,
+		"retryPeriod", options.LeaderElectionRetryPeriod)
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		Port:                    operatorMetricsPort,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloud-operators-placementrule-leader.open-cluster-management.io",
 		LeaderElectionNamespace: "kube-system",
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		LeaseDuration:           &options.LeaderElectionLeaseDuration,
+		RenewDeadline:           &options.LeaderElectionRenewDeadline,
+		RetryPeriod:             &options.LeaderElectionRetryPeriod,
 		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
 	})
 

--- a/cmd/placementrule/exec/options.go
+++ b/cmd/placementrule/exec/options.go
@@ -15,24 +15,26 @@
 package exec
 
 import (
+	"time"
+
 	pflag "github.com/spf13/pflag"
 )
 
 // PlacementRuleCMDOptions for command line flag parsing
 type PlacementRuleCMDOptions struct {
-	MetricsAddr                        string
-	KubeConfig                         string
-	LeaderElectionLeaseDurationSeconds int
-	RenewDeadlineSeconds               int
-	RetryPeriodSeconds                 int
+	MetricsAddr                 string
+	KubeConfig                  string
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }
 
 var options = PlacementRuleCMDOptions{
-	MetricsAddr:                        "",
-	KubeConfig:                         "",
-	LeaderElectionLeaseDurationSeconds: 137,
-	RenewDeadlineSeconds:               107,
-	RetryPeriodSeconds:                 26,
+	MetricsAddr:                 "",
+	KubeConfig:                  "",
+	LeaderElectionLeaseDuration: 137 * time.Second,
+	LeaderElectionRenewDeadline: 107 * time.Second,
+	LeaderElectionRetryPeriod:   26 * time.Second,
 }
 
 // ProcessFlags parses command line parameters into options
@@ -53,24 +55,31 @@ func ProcessFlags() {
 		"The kube config that points to a external api server.",
 	)
 
-	flag.IntVar(
-		&options.LeaderElectionLeaseDurationSeconds,
+	flag.DurationVar(
+		&options.LeaderElectionLeaseDuration,
 		"leader-election-lease-duration",
-		options.LeaderElectionLeaseDurationSeconds,
-		"The leader election lease duration in seconds.",
+		options.LeaderElectionLeaseDuration,
+		"The duration that non-leader candidates will wait after observing a leadership "+
+			"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+			"slot. This is effectively the maximum duration that a leader can be stopped "+
+			"before it is replaced by another candidate. This is only applicable if leader "+
+			"election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RenewDeadlineSeconds,
-		"renew-deadline",
-		options.RenewDeadlineSeconds,
-		"The renew deadline in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRenewDeadline,
+		"leader-election-renew-deadline",
+		options.LeaderElectionRenewDeadline,
+		"The interval between attempts by the acting master to renew a leadership slot "+
+			"before it stops leading. This must be less than or equal to the lease duration. "+
+			"This is only applicable if leader election is enabled.",
 	)
 
-	flag.IntVar(
-		&options.RetryPeriodSeconds,
-		"retry-period",
-		options.RetryPeriodSeconds,
-		"The retry period in seconds.",
+	flag.DurationVar(
+		&options.LeaderElectionRetryPeriod,
+		"leader-election-retry-period",
+		options.LeaderElectionRetryPeriod,
+		"The duration the clients should wait between attempting acquisition and renewal "+
+			"of a leadership. This is only applicable if leader election is enabled.",
 	)
 }

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -483,9 +483,9 @@ spec:
                 imagePullPolicy: IfNotPresent
                 command:
                 - /usr/local/bin/propagation
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 livenessProbe:
                   exec:
                     command:
@@ -519,9 +519,9 @@ spec:
                 - /usr/local/bin/gitopssyncresc
                 - --appset-resource-dir=/etc/gitops-resources
                 - --sync-interval=10
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -566,9 +566,9 @@ spec:
                 - /usr/local/bin/multiclusterstatusaggregation
                 - --appset-resource-dir=/etc/gitops-resources
                 - --sync-interval=10
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -651,9 +651,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-placementrule
                 - --alsologtostderr
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -696,9 +696,9 @@ spec:
               - command:
                 - /usr/local/bin/gitopscluster
                 - --alsologtostderr
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -741,9 +741,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-application
                 - --alsologtostderr
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 ports:
                 - containerPort: 9442
                   name: app-whk-server
@@ -832,9 +832,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-channel
                 - --alsologtostderr
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 ports:
                 - containerPort: 9443            
                   name: chn-whk-server
@@ -920,9 +920,9 @@ spec:
               containers:
               - command:
                 - /usr/local/bin/appsubsummary
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -1008,9 +1008,9 @@ spec:
                 - /usr/local/bin/multicluster-operators-subscription
                 - --standalone
                 - --sync-interval=60
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 env:
                 - name: WATCH_NAMESPACE
                 - name: POD_NAME
@@ -1100,9 +1100,9 @@ spec:
               - command:
                 - /usr/local/bin/multicluster-operators-subscription
                 - --sync-interval=60
-                - --leader-election-lease-duration=137
-                - --renew-deadline=107
-                - --retry-period=26
+                - --leader-election-lease-duration=137s
+                - --leader-election-renew-deadline=107s
+                - --leader-election-retry-period=26s
                 ports:
                 - containerPort: 8443            
                 env:


### PR DESCRIPTION
This PR updates the leader election settings and renames the leader election options from 
``` 
--renew-deadline ==> leader-election-renew-deadline
--retry-period ==> leader-election-retry-period
```