### PR TITLE
Up multicluster-integrations-aggregation controller memory to 1Gi

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -598,7 +598,7 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 512Mi
+                    memory: 1Gi
                   requests:
                     cpu: 25m
                     memory: 64Mi


### PR DESCRIPTION
This PR is to increase the aggregation controller's memory limit from 512Mi to 1Gi in the CSV.