### PR TITLE
Add app field to appsetreport

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_multiclusterapplicationsetreports.yaml
@@ -60,6 +60,8 @@ spec:
                       type: string
                     syncStatus:
                       type: string
+                    app:
+                      type: string
                   type: object
                 type: array
               resources:


### PR DESCRIPTION
This PR modifies the appsetreport CRD by adding a new app field to save the app namespaced name for each cluster. 