### PR TITLE
ACM-5225 Enforce server side TLSv1.3

### DIFF
--- a/cmd/appsubsummary/exec/manager.go
+++ b/cmd/appsubsummary/exec/manager.go
@@ -80,7 +80,7 @@ func RunManager() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
-		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.3"},
 		ClientDisableCacheFor:   []client.Object{&corev1.Secret{}, &corev1.ServiceAccount{}},
 	})
 	if err != nil {

--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -125,7 +125,7 @@ func RunManager() {
 		LeaseDuration:           &Options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &Options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &Options.LeaderElectionRetryPeriod,
-		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.3"},
 		ClientDisableCacheFor:   []client.Object{&corev1.Secret{}, &corev1.ServiceAccount{}},
 	})
 

--- a/cmd/placementrule/exec/manager.go
+++ b/cmd/placementrule/exec/manager.go
@@ -82,7 +82,7 @@ func RunManager() {
 		LeaseDuration:           &options.LeaderElectionLeaseDuration,
 		RenewDeadline:           &options.LeaderElectionRenewDeadline,
 		RetryPeriod:             &options.LeaderElectionRetryPeriod,
-		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.2"},
+		WebhookServer:           &k8swebhook.Server{TLSMinVersion: "1.3"},
 	})
 
 	if err != nil {

--- a/pkg/helmrelease/utils/helmrepoutils.go
+++ b/pkg/helmrelease/utils/helmrepoutils.go
@@ -404,7 +404,7 @@ func getSSHOptions(options *git.CloneOptions, sshKey, passphrase []byte, knownho
 func getHTTPOptions(options *git.CloneOptions, caCerts string, insecureSkipVerify bool) error {
 	installProtocol := false
 
-	clientConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	clientConfig := &tls.Config{MinVersion: tls.VersionTLS13}
 
 	// skip TLS certificate verification for Git servers with custom or self-signed certs
 	if insecureSkipVerify {

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -487,7 +487,7 @@ func getHTTPOptions(options *git.CloneOptions, user, password, caCerts string, i
 
 	installProtocol := false
 
-	clientConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	clientConfig := &tls.Config{MinVersion: tls.VersionTLS13}
 
 	// skip TLS certificate verification for Git servers with custom or self-signed certs
 	if insecureSkipVerify {

--- a/pkg/webhook/listener/webhook_listner.go
+++ b/pkg/webhook/listener/webhook_listner.go
@@ -118,7 +118,7 @@ func (listener *WebhookListener) Start(ctx context.Context) error {
 			Addr:              ":8443",
 			Handler:           mux,
 			ReadHeaderTimeout: 32 * time.Second,
-			TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12},
+			TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS13},
 		}
 
 		klog.Fatal(s.ListenAndServeTLS(listener.TLSCrtFile, listener.TLSKeyFile))


### PR DESCRIPTION
This PR enforces sever side TLSv1.3, confirmed using nmap script ssl-enum-ciphers:

Before enforcement:
```
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|        ...
|   TLSv1.3: 
|     ciphers: 
|       ...
|_  least strength: C
```
After:
```
| ssl-enum-ciphers: 
|   TLSv1.3: 
|     ciphers: 
|      ...
|_  least strength: A
```

Addresses:
 - https://issues.redhat.com/browse/ACM-5225