### PR TITLE
Prevent push triggered ci workflows from running on forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
-    if: ${{ github.repository.fork == false }}
+    if: github.repository_owner == 'open-cluster-management-io'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -19,7 +19,7 @@ jobs:
   images:
     name: images
     runs-on: ubuntu-latest
-    if: ${{ github.repository.fork == false }}
+    if: github.repository_owner == 'open-cluster-management-io'
     steps:
       - name: checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

The previous patch merged from https://github.com/open-cluster-management-io/multicloud-operators-subscription/pull/249 didn't actually worked. This one works for multiple repositories I maintain.

