### PR TITLE
Ensure subscription CRDs are applied before starting controller

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -37,6 +37,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	spokeClusterV1 "open-cluster-management.io/api/cluster/v1"
@@ -264,6 +267,65 @@ func RunManager() {
 	if !Options.Standalone && Options.ClusterName == "" {
 		klog.Info("Detecting ACM Placement Decision API on the hub...")
 		utils.DetectPlacementDecision(sig, mgr.GetAPIReader(), mgr.GetClient())
+	}
+
+	if Options.ClusterName == "" {
+		crdxhub, err := clientset.NewForConfig(hubconfig)
+		if err != nil {
+			klog.Error("unable to build clientset for Subscription CRD check on hub cluster")
+			os.Exit(1)
+		}
+
+		klog.Info("Detecting Subscription API on the hub...")
+
+		for {
+			var err error
+
+			crds := [3]string{"subscriptions.apps.open-cluster-management.io",
+				"subscriptionstatuses.apps.open-cluster-management.io", "subscriptionreports.apps.open-cluster-management.io"}
+			for _, crd := range crds {
+				_, err = crdxhub.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd, apimachineryv1.GetOptions{})
+				if err != nil {
+					break
+				}
+			}
+
+			if err != nil {
+				klog.Error("Subscription API is NOT ready: ", err)
+				time.Sleep(10 * time.Second)
+			} else {
+				klog.Info("Subscription API is ready.")
+				break
+			}
+		}
+	} else {
+		crdxmanaged, err := clientset.NewForConfig(mgr.GetConfig())
+		if err != nil {
+			klog.Error("unable to build clientset for Subscription CRD check on managed cluster")
+			os.Exit(1)
+		}
+
+		klog.Info("Detecting Subscription API...")
+
+		for {
+			var err error
+
+			crds := [2]string{"subscriptions.apps.open-cluster-management.io", "subscriptionstatuses.apps.open-cluster-management.io"}
+			for _, crd := range crds {
+				_, err = crdxmanaged.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd, apimachineryv1.GetOptions{})
+				if err != nil {
+					break
+				}
+			}
+
+			if err != nil {
+				klog.Error("Subscription API is NOT ready: ", err)
+				time.Sleep(10 * time.Second)
+			} else {
+				klog.Info("Subscription API is ready.")
+				break
+			}
+		}
 	}
 
 	klog.Info("Starting the Cmd.")

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -1228,6 +1228,48 @@ func IsReadyPlacementDecision(clReader client.Reader) bool {
 	return true
 }
 
+// IsReadySubscription check if Subscription API is ready or not.
+func IsReadySubscription(clReader client.Reader, hub bool) bool {
+	subList := appv1.SubscriptionList{}
+
+	listopts := &client.ListOptions{}
+
+	err := clReader.List(context.TODO(), &subList, listopts)
+	if err != nil {
+		klog.Error("Subscription API NOT ready: ", err)
+
+		return false
+	}
+
+	subStatusList := appsubReportV1alpha1.SubscriptionStatusList{}
+
+	err = clReader.List(context.TODO(), &subStatusList, listopts)
+	if err != nil {
+		klog.Error("SubscriptionStatus API NOT ready: ", err)
+
+		return false
+	}
+
+	if hub {
+		subReportList := appsubReportV1alpha1.SubscriptionReportList{}
+
+		err = clReader.List(context.TODO(), &subReportList, listopts)
+		if err != nil {
+			klog.Error("SubscriptionReport API NOT ready: ", err)
+
+			return false
+		}
+
+		klog.Info("Subscription, SubscriptionStatus and SubscriptionReport APIs are ready")
+
+		return true
+	}
+
+	klog.Info("Subscription, and SubscriptionStatus APIs are ready")
+
+	return true
+}
+
 func CreateClusterManagementAddon(clt client.Client) {
 	cma := &addonV1alpha1.ClusterManagementAddOn{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -1703,6 +1703,7 @@ func TestIsReadyPlacementDecision(t *testing.T) {
 	ret := IsReadyPlacementDecision(mgr.GetAPIReader())
 	g.Expect(ret).To(BeFalse())
 }
+
 func TestFetchChannelReferences(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -1704,6 +1704,27 @@ func TestIsReadyPlacementDecision(t *testing.T) {
 	g.Expect(ret).To(BeFalse())
 }
 
+func TestIsReadySubscription(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+	// channel when it is finished.
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	// Subscription API should NOT be ready.
+	ret := IsReadySubscription(mgr.GetAPIReader(), true)
+	g.Expect(ret).To(BeFalse())
+}
+
 func TestFetchChannelReferences(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
This PR is to check if the `subscription`, `subscriptionStatus`, and `SubscriptionReport` CRDs are loaded before starting the controller. When the controller is starting up, if any of the CRDs are not found, a loop will check for the CRDs every 10 seconds until they all appear, killing the controller allowing it to restart with the CRDs applied. 

Meant to help address: https://issues.redhat.com/browse/ACM-5451