### PR TITLE
Revert "Declare seccompProfile to avoid PodSecurity warnings (#337)"

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -507,8 +507,6 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-                  seccompProfile:
-                    type: RuntimeDefault
                   capabilities:
                     drop:
                     - ALL
@@ -610,8 +608,6 @@ spec:
                   readOnly: false
               securityContext:
                 runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
               serviceAccountName: multicluster-applications
               volumes:
               - name: multicluster-integrations-syncresource 
@@ -630,8 +626,6 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
@@ -902,8 +896,6 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This change was requested by ACM Installer Team to address logging errors in OCP4.11+, but we are also supporting 4.10 and this is incompatible there, causing pods to crash. Please revert this change, we are going to reassess how to handle the logging warnings from our end.

Signed-off-by: Erin Murphy erinmurp@redhat.com