### PR TITLE
Remove static from build

### DIFF
--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -46,5 +46,5 @@ if [[ "${STATIC}" !=  "1" ]];then
 fi
 
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
-        -a -tags static \
+        -a \
         -o "${OUT}" "${@}"


### PR DESCRIPTION
* [x] I have taken backward compatibility into consideration.

Remove static flag from build parameters.