### PR TITLE
Set to Go 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/multicloud-operators-subscription
 
-go 1.22.10
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Setting to the latest z-stream is incompatible
with downstream build systems. Setting to the
lowest possible to be safe.

* [x] I have taken backward compatibility into consideration.
