### PR TITLE
Implement Objectstore TLS support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
 - xiangjingli
 - lennysgarage
 - chenz4027
+- fxiang1
 reviewers:
 - jnpacker
 - mikeshng
@@ -14,3 +15,4 @@ reviewers:
 - xiangjingli
 - lennysgarage
 - chenz4027
+- fxiang1

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
@@ -111,7 +111,8 @@ func (obsi *SubscriberItem) Stop() {
 	}
 }
 
-func (obsi *SubscriberItem) getChannelConfig(primary bool) (endpoint, accessKeyID, secretAccessKey, region string, err error) {
+func (obsi *SubscriberItem) getChannelConfig(primary bool) (
+	endpoint, accessKeyID, secretAccessKey, region string, objInsecureSkipVerify, objCaCert string, err error) {
 	utils.UpdateLastUpdateTime(obsi.synchronizer.GetLocalClient(), obsi.Subscription)
 
 	channel := obsi.Channel
@@ -126,7 +127,7 @@ func (obsi *SubscriberItem) getChannelConfig(primary bool) (endpoint, accessKeyI
 		errmsg := "Empty Pathname in channel " + channel.Name
 		klog.Error(errmsg)
 
-		return "", "", "", "", errors.New(errmsg)
+		return "", "", "", "", "", "", errors.New(errmsg)
 	}
 
 	if strings.HasSuffix(pathName, "/") {
@@ -138,6 +139,7 @@ func (obsi *SubscriberItem) getChannelConfig(primary bool) (endpoint, accessKeyI
 	endpoint = pathName[:loc]
 	obsi.bucket = pathName[loc+1:]
 	secret := obsi.ChannelSecret
+	configMap := obsi.ChannelConfigMap
 
 	if !primary {
 		secret = obsi.SecondaryChannelSecret
@@ -148,14 +150,14 @@ func (obsi *SubscriberItem) getChannelConfig(primary bool) (endpoint, accessKeyI
 		if err != nil {
 			klog.Error("Failed to unmashall accessKey from secret with error:", err)
 
-			return "", "", "", "", err
+			return "", "", "", "", "", "", err
 		}
 
 		err = yaml.Unmarshal(secret.Data[awsutils.SecretMapKeySecretAccessKey], &secretAccessKey)
 		if err != nil {
 			klog.Error("Failed to unmashall secretaccessKey from secret with error:", err)
 
-			return "", "", "", "", err
+			return "", "", "", "", "", "", err
 		}
 
 		regionData := secret.Data[awsutils.SecretMapKeyRegion]
@@ -165,18 +167,29 @@ func (obsi *SubscriberItem) getChannelConfig(primary bool) (endpoint, accessKeyI
 			if err != nil {
 				klog.Error("Failed to unmashall region from secret with error:", err)
 
-				return "", "", "", "", err
+				return "", "", "", "", "", "", err
 			}
 		}
 	}
 
-	return endpoint, accessKeyID, secretAccessKey, region, nil
+	if configMap != nil {
+		objCaCert = configMap.Data[appv1.ChannelCertificateData]
+		if objCaCert != "" {
+			klog.Info("ObjectStore channel config map with CA certs found")
+		}
+	}
+
+	if channel.Spec.InsecureSkipVerify {
+		objInsecureSkipVerify = "true"
+	}
+
+	return endpoint, accessKeyID, secretAccessKey, region, objInsecureSkipVerify, objCaCert, nil
 }
 
 func (obsi *SubscriberItem) getAwsHandler(primary bool) error {
 	awshandler := &awsutils.Handler{}
 
-	endpoint, accessKeyID, secretAccessKey, region, err := obsi.getChannelConfig(primary)
+	endpoint, accessKeyID, secretAccessKey, region, objInsecureSkipVerify, objCaCert, err := obsi.getChannelConfig(primary)
 
 	if err != nil {
 		return err
@@ -184,7 +197,8 @@ func (obsi *SubscriberItem) getAwsHandler(primary bool) error {
 
 	klog.V(1).Info("Trying to connect to object bucket ", endpoint, "|", obsi.bucket)
 
-	if err := awshandler.InitObjectStoreConnection(endpoint, accessKeyID, secretAccessKey, region); err != nil {
+	if err := awshandler.InitObjectStoreConnection(
+		endpoint, accessKeyID, secretAccessKey, region, objInsecureSkipVerify, objCaCert); err != nil {
 		klog.Error(err, "unable initialize object store settings")
 		return err
 	}

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_test.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_test.go
@@ -199,7 +199,7 @@ func TestObjectSubscriber(t *testing.T) {
 	obssubitem.ChannelConfigMap = channelConfigMap
 
 	// Test 1: test get object Channel Config
-	endpoint, accessKeyID, secretAccessKey, region, err := obssubitem.getChannelConfig(true)
+	endpoint, accessKeyID, secretAccessKey, region, _, _, err := obssubitem.getChannelConfig(true)
 
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(endpoint).To(gomega.Equal("http://minio-minio.apps.hivemind-b.aws.red-chesterfield.com"))
@@ -256,7 +256,7 @@ func TestObjectSubscriber(t *testing.T) {
 
 	objChannel.Spec.Pathname = ts.URL + "/fake-bucket"
 	awshandler := &awsutils.Handler{}
-	err = awshandler.InitObjectStoreConnection(ts.URL, "test-access-id", "test-secret-access-key", "test-region")
+	err = awshandler.InitObjectStoreConnection(ts.URL, "test-access-id", "test-secret-access-key", "test-region", "false", "")
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = awshandler.Create("fake-bucket")

--- a/pkg/utils/aws/objectstore.go
+++ b/pkg/utils/aws/objectstore.go
@@ -17,18 +17,25 @@ package aws
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"k8s.io/klog/v2"
+
+	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
 // ObjectStore interface.
 type ObjectStore interface {
-	InitObjectStoreConnection(endpoint, accessKeyID, secretAccessKey, region string) error
+	InitObjectStoreConnection(
+		endpoint, accessKeyID, secretAccessKey, region string, objInsecureSkipVerify, objCaCert string) error
 	Exists(bucket string) error
 	Create(bucket string) error
 	List(bucket string, folderName *string) ([]string, error)
@@ -104,8 +111,39 @@ func isAwsS3ObjectBucket(endpoint string) bool {
 	return false
 }
 
+// Creates a custom TLS config using the caCert passed in from cofigmapRef in the Channel
+func createCustomTLSConfig(objInsecureSkipVerify, objCaCert string) *tls.Config {
+	tlsConfig := &tls.Config{
+		MinVersion: appv1.TLSMinVersionInt, // #nosec G402
+		// set it to true or false based on channel.spec.insecureSkipVerify
+		InsecureSkipVerify: false,
+	}
+
+	if objInsecureSkipVerify == "true" { // #nosec G402
+		tlsConfig = &tls.Config{
+			MinVersion: appv1.TLSMinVersionInt,
+			// set it to true or false based on channel.spec.insecureSkipVerify
+			InsecureSkipVerify: true,
+		}
+
+		return tlsConfig
+	} else if !strings.EqualFold(objCaCert, "") {
+		// Add custom root CA certificate (for private/enterprise S3-compatible stores)
+		rootCAPool := x509.NewCertPool()
+		if !rootCAPool.AppendCertsFromPEM([]byte(objCaCert)) {
+			klog.Fatalf("Failed to parse root CA certificate")
+			return tlsConfig
+		}
+
+		tlsConfig.RootCAs = rootCAPool
+	}
+
+	return tlsConfig
+}
+
 // InitObjectStoreConnection connect to object store.
-func (h *Handler) InitObjectStoreConnection(endpoint, accessKeyID, secretAccessKey, region string) error {
+func (h *Handler) InitObjectStoreConnection(
+	endpoint, accessKeyID, secretAccessKey, region, objInsecureSkipVerify, objCaCert string) error {
 	klog.Infof("Preparing S3 settings endpoint: %v", endpoint)
 
 	// set the default object store region  as minio
@@ -130,7 +168,30 @@ func (h *Handler) InitObjectStoreConnection(endpoint, accessKeyID, secretAccessK
 		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
 	})
 
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolverWithOptions(customResolver))
+	// Create a custom HTTP transport with TLS configuration
+	transport := &http.Transport{
+		// Custom TLS configuration
+		TLSClientConfig: createCustomTLSConfig(objInsecureSkipVerify, objCaCert),
+
+		// Optional: Customize connection pooling and timeouts
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+		DisableCompression:  false,
+	}
+
+	// Create a custom HTTP client
+	httpClient := &http.Client{
+		Transport: transport,
+
+		// Optional: Set request timeouts
+		Timeout: 30 * time.Second,
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithEndpointResolverWithOptions(customResolver),
+		config.WithHTTPClient(httpClient))
+
 	if err != nil {
 		klog.Error("Failed to load aws config. error: ", err)
 
@@ -146,6 +207,8 @@ func (h *Handler) InitObjectStoreConnection(endpoint, accessKeyID, secretAccessK
 
 	h.Client = s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.Region = objectRegion
+		// For Git they just set both caCert and credential to the config
+		// and let the Git API handle it, so we do the same here
 		o.Credentials = objCredential
 	})
 

--- a/pkg/utils/aws/objectstore_test.go
+++ b/pkg/utils/aws/objectstore_test.go
@@ -35,7 +35,7 @@ func TestObjectstore(t *testing.T) {
 
 	awshandler := &Handler{}
 
-	err := awshandler.InitObjectStoreConnection(ts.URL, "randomid", "randomkey", "minio")
+	err := awshandler.InitObjectStoreConnection(ts.URL, "randomid", "randomkey", "minio", "false", "")
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Invalid bucket name
@@ -109,4 +109,49 @@ func TestObjectstore(t *testing.T) {
 	// Check if the item is deleted now
 	_, err = awshandler.Get("test", "testObj")
 	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestObjectstoreInsecureSkipVerify(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// Set up a fake S3 server
+	backend := s3mem.New()
+	faker := gofakes3.New(backend)
+	ts := httptest.NewServer(faker.Server())
+
+	defer ts.Close()
+
+	awshandler := &Handler{}
+
+	err := awshandler.InitObjectStoreConnection(ts.URL, "randomid", "randomkey", "minio", "true", "")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func TestObjectstoreTLSCert(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// Set up a fake S3 server
+	backend := s3mem.New()
+	faker := gofakes3.New(backend)
+	ts := httptest.NewServer(faker.Server())
+
+	defer ts.Close()
+
+	tlsCert := `
+-----BEGIN CERTIFICATE-----
+MIIBbDCCARKgAwIBAgIQGr0mPSgSVkL+LGyc4t6sizAKBggqhkjOPQQDAjAWMRQw
+EgYDVQQDEwt0ZW5hbnQtMS1jYTAeFw0yNTAxMDcyMjQ3MzFaFw0zMzAxMDcyMjQ3
+MzFaMBYxFDASBgNVBAMTC3RlbmFudC0xLWNhMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEb4EbeQaePR7esEsWLaa8K1CP5wsepByUohpObyK4vQNLZD1qfEP0gyRJ
+ra9NHqsjwvqb1vhc89ki4SmUu4wvzaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1Ud
+EwEB/wQFMAMBAf8wHQYDVR0OBBYEFDGMqDQqNdgnHrQ9ugwF+Gz3KoVOMAoGCCqG
+SM49BAMCA0gAMEUCIF6SNjLpdiGsJNPDVdV0Lxn1KrXnDqydp0jhz7G86PdyAiEA
+9/Mtq43sOFkkPlNoncNUujgvvBbatqAkFtLjdbkeTA8=
+-----END CERTIFICATE-----
+`
+
+	awshandler := &Handler{}
+
+	err := awshandler.InitObjectStoreConnection(ts.URL, "randomid", "randomkey", "minio", "false", tlsCert)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 }


### PR DESCRIPTION
* [x] I have taken backward compatibility into consideration.

- Add Channel insecureSkipVerify support for Objectbucket
- Add Channel configMapRef support for TLS certs
- insecureSkipVerify will override cert when both are specified

Example channel:
```
apiVersion: apps.open-cluster-management.io/v1
kind: Channel
metadata:
  name: object-dev
  namespace: ch-object-dev
spec:
  type: ObjectBucket
  pathname: https://s3.console.aws.amazon.com/s3/buckets/feng-bucket
  secretRef:
    name: secret-dev
  insecureSkipVerify: true
  configMapRef:
    name: obj-ca
```

Example configMap:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: obj-ca
  namespace: ch-object-dev
data:
  caCerts: |
    # minio root CA

    -----BEGIN CERTIFICATE-----
    ...Sample cert...
    -----END CERTIFICATE-----
```