### PR TITLE
Fix hub subscription pod crash on invalid cert

### DIFF
--- a/pkg/utils/aws/objectstore.go
+++ b/pkg/utils/aws/objectstore.go
@@ -131,7 +131,7 @@ func createCustomTLSConfig(objInsecureSkipVerify, objCaCert string) *tls.Config 
 		// Add custom root CA certificate (for private/enterprise S3-compatible stores)
 		rootCAPool := x509.NewCertPool()
 		if !rootCAPool.AppendCertsFromPEM([]byte(objCaCert)) {
-			klog.Fatalf("Failed to parse root CA certificate")
+			klog.Infof("Failed to parse root CA certificate")
 			return tlsConfig
 		}
 


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.


- Changed a FatalF message output to InfoF so the hub subscription pod doesn't crash when the user provide an invalid TLS certificate