### PR TITLE
feat: Add an annotation to allow for hub appsub bypassing Git clone

### DIFF
--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -96,6 +96,8 @@ var (
 	AnnotationHostingDeployable = SchemeGroupVersion.Group + "/hosting-deployable"
 	// AnnotationCurrentNamespaceScoped specifies to deloy resources into subscription namespace
 	AnnotationCurrentNamespaceScoped = SchemeGroupVersion.Group + "/current-namespace-scoped"
+	// AnnotationSkipHubValidation indicates the hub subscription should skip the "dry-run" validations and proceed to propagation phase
+	AnnotationSkipHubValidation = SchemeGroupVersion.Group + "/skip-hub-validation"
 )
 
 const (

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -93,6 +93,17 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1.Subscription) error
 	// Add or sync application labels
 	r.AddAppLabels(sub)
 
+	// Skip fetching resources and creating appsub report if skip hub validation is true
+	if shouldSkipHubValidation(sub) {
+		clusters, err := r.getClustersByPlacement(sub)
+		if err != nil {
+			klog.Error("Error in getting clusters:", err)
+			return err
+		}
+
+		return r.PropagateAppSubManifestWork(sub, clusters)
+	}
+
 	var resources []*v1.ObjectReference
 
 	switch tp := strings.ToLower(string(primaryChannel.Spec.Type)); tp {

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -342,6 +342,11 @@ func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) error {
 	h.logger.Info("entry register branch for appsub " + subIns.Namespace + "/" + subIns.Name)
 	defer h.logger.Info("exit register branch for appsub " + subIns.Namespace + "/" + subIns.Name)
 
+	if shouldSkipHubValidation(subIns) {
+		h.logger.Info("skipping register branch for appsub " + subIns.Namespace + "/" + subIns.Name)
+		return nil
+	}
+
 	subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
 
 	// This does not pick up new changes to channel configuration
@@ -780,4 +785,13 @@ func (h *HubGitOps) GetHooks(subIns *subv1.Subscription, hookPath string) ([]ans
 	}
 
 	return newAnsibleJobs, nil
+}
+
+func shouldSkipHubValidation(subIns *subv1.Subscription) bool {
+	annos := subIns.GetAnnotations()
+	if len(annos) > 0 && annos[subv1.AnnotationSkipHubValidation] == "true" {
+		return true
+	}
+
+	return false
 }

--- a/pkg/controller/mcmhub/hub_git_test.go
+++ b/pkg/controller/mcmhub/hub_git_test.go
@@ -431,3 +431,50 @@ var _ = PDescribe("hub git ops", func() {
 		Eventually(detectTargetCommit(subKey, defaultCommit), specTimeOut, pullInterval).Should(Succeed())
 	})
 })
+
+var _ = Describe("shouldSkipHubValidation", func() {
+	var (
+		sub *subv1.Subscription
+	)
+	BeforeEach(func() {
+		sub = &subv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sub",
+				Namespace: "default",
+			},
+		}
+	})
+	It("should return false when annotation is nil", func() {
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return false when skip annotation is missing", func() {
+		sub.SetAnnotations(map[string]string{
+			"foobar": "true",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return true when skip annotation is true'", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "true",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeTrue())
+	})
+	It("should return false when skip annotation is empty", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return false when skip annotation is false", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "false",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return false when skip annotation is non boolean string values", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "foobar",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+})

--- a/test/e2e/cases/000-git-skip-clone/channel.yaml
+++ b/test/e2e/cases/000-git-skip-clone/channel.yaml
@@ -1,11 +1,10 @@
----
 apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
-  name: git
+  name: gitops
   namespace: default
   annotations:
     apps.open-cluster-management.io/reconcile-rate: high
 spec:
-  type: git
   pathname: 'https://github.com/open-cluster-management-io/multicloud-operators-subscription.git'
+  type: Git

--- a/test/e2e/cases/000-git-skip-clone/placement.yaml
+++ b/test/e2e/cases/000-git-skip-clone/placement.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: git-pr
+  namespace: default
+spec:
+  clusterReplicas: 2

--- a/test/e2e/cases/000-git-skip-clone/subscription.yaml
+++ b/test/e2e/cases/000-git-skip-clone/subscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: test/e2e/cases/13-git-res-name/resource
+    apps.open-cluster-management.io/skip-hub-validation: 'true'
+  name: git-hub-skip-clone
+  namespace: default
+spec:
+  channel: default/gitops
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: git-pr

--- a/test/e2e/cases/23-git-appsub-status-failed/03-subscription.yaml
+++ b/test/e2e/cases/23-git-appsub-status-failed/03-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: guestbook-failed
   namespace: default
   annotations:
-    apps.open-cluster-management.io/github-path: guestbook-failed
+    apps.open-cluster-management.io/github-path: test/e2e/cases/23-git-appsub-status-failed/resource
     apps.open-cluster-management.io/github-branch: main    
 spec:
   channel: default/git


### PR DESCRIPTION
feat: Add an annotation to allow for hub appsub bypassing Git clone operations to speed up appsub propagation to managed cluster

The annotation is placed on the hub appsub. An example is:

```
apiVersion: apps.open-cluster-management.io/v1
kind: Subscription
metadata:
  annotations:
    apps.open-cluster-management.io/skip-hub-validation: 'true'
```

* [x] I have taken backward compatibility into consideration.
